### PR TITLE
76 add new task issue template for remedialmaintenance work

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -16,6 +16,11 @@ issue_templates:
     file: workflow_gap.md
     labels: ["workflow-gap", "enhancement"]
 
+  - name: "🧹 Task"
+    description: "Track remedial or maintenance work (not a bug or feature)"
+    file: task.md
+    labels: ["task"]
+
 contact_links:
   - name: "📖 Documentation"
     url: "https://github.com/NOAA-GSL/zyra/wiki"

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,16 @@
+---
+name: "🧹 Task"
+about: "Track remedial or maintenance work that is not a bug or feature"
+title: "[Task] "
+labels: ["task"]
+assignees: ""
+---
+
+## Summary
+_A clear, one-sentence description of the task._
+
+## Details
+_Optional: Any extra context, motivation, or background for why this needs to be done._
+
+## Acceptance Criteria
+- [ ] Clear, testable conditions that define when this task is complete

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,8 @@ Provide a short summary of the changes in this PR.
 
 ## Related Issue
 
-Closes #<issue-number>  
-(Ensure this PR links to a **Workflow Gap** issue if adding new CLI functionality)
+Closes #<issue-number> (or Links to: #<issue-number>)  
+Select one: Bug | Feature | Workflow Gap | Task
 
 ## Changes
 
@@ -16,12 +16,27 @@ Closes #<issue-number>
 - [ ] Verified comprehensive **docstrings** for auto-generated documentation
 - [ ] Added/updated example in sample workflows
 
+## Type of Change
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Workflow Gap implementation
+- [ ] 🧹 Task (maintenance/refactor/CI/docs)
+- [ ] Docs only / CI only
+- [ ] Refactor (no functional change)
+
+## Impact / Risk
+Describe impact, blast radius, and any rollback considerations.
+
+## Validation Steps
+List steps for reviewers to verify this change (commands, expected results).
+
 ## Checklist
 
 - [ ] Code follows project style guidelines
 - [ ] All tests pass locally
 - [ ] Documentation builds cleanly from docstrings
-- [ ] I have linked this PR to a relevant issue
+- [ ] I have linked this PR to a relevant issue (Bug/Feature/Workflow Gap/Task)
+- [ ] No secrets or credentials added; follows repo guardrails
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,12 @@ Provide a short summary of the changes in this PR.
 ## Related Issue
 
 Closes #<issue-number> (or Links to: #<issue-number>)  
-Select one: Bug | Feature | Workflow Gap | Task
 
+## Issue Type
+- [ ] Bug
+- [ ] Feature
+- [ ] Workflow Gap
+- [ ] Task
 ## Changes
 
 - [ ] Implemented functionality in `src/zyra/`

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,17 @@
+labels:
+  - name: bug
+    color: d73a4a
+    description: "Something isn't working"
+
+  - name: enhancement
+    color: a2eeef
+    description: "New feature or request"
+
+  - name: workflow-gap
+    color: fbca04
+    description: "Missing CLI functionality or structural gap"
+
+  - name: task
+    color: c5def5
+    description: "Remedial or maintenance work (not a bug or feature)"
+

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -2,7 +2,6 @@ name: Sync Labels
 
 on:
   push:
-    branches: [ $default-branch ]
     paths:
       - '.github/labels.yml'
       - '.github/workflows/sync-labels.yml'
@@ -11,10 +10,10 @@ on:
 permissions:
   contents: read
   issues: write
-  metadata: read
 
 jobs:
   sync:
+    if: github.event_name == 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,29 @@
+name: Sync Labels
+
+on:
+  push:
+    branches: [ $default-branch ]
+    paths:
+      - '.github/labels.yml'
+      - '.github/workflows/sync-labels.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+  metadata: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          yaml_file: .github/labels.yml
+          skip_delete: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,17 @@ Zyra now uses structured **Workflow Gap** issue and PR templates to ensure new C
   - Why the feature is needed
 - The template will guide you to include an implementation plan and examples.
 
+### Filing Task Issues (Maintenance / Chores)
+- Use the `🧹 Task` template (`.github/ISSUE_TEMPLATE/task.md`).
+- Use this for non-functional work such as refactors, dependency updates, CI or docs maintenance, code hygiene, and cleanup tasks.
+- Do not use for bugs or new features; if the work changes CLI semantics or adds commands, prefer the appropriate Bug/Feature/Workflow Gap template.
+- Please include:
+  - A concise scope statement (what is and is not in scope)
+  - Acceptance criteria (clear, testable completion conditions)
+  - Impact/risk notes (blast radius, rollback considerations)
+  - Validation steps (how reviewers can verify the task)
+  - Links to related issues/PRs
+
 ### Submitting PRs for Workflow Gaps
 - All PRs that add CLI functionality should link to the related Workflow Gap issue.
 - The PR template (`.github/PULL_REQUEST_TEMPLATE.md`) includes a checklist:
@@ -113,6 +124,7 @@ By following these templates, contributors help keep Zyra’s CLI aligned with r
 - Make sure your branch is up-to-date with `staging`.  
 - Include descriptive commit messages.  
 - Request a review from at least one maintainer.  
+ - Link the related issue (Bug/Feature/Workflow Gap/Task) in the PR description.  
 
 ---
 


### PR DESCRIPTION
This pull request introduces improved support for tracking maintenance and remedial work by adding a dedicated "Task" issue template and label, updating documentation to clarify usage, and enhancing the pull request workflow. These changes help distinguish non-functional work (such as refactoring, CI updates, or documentation) from bugs, features, and workflow gaps, making project management clearer and more structured.

**Issue and Label Management**

* Added a new `🧹 Task` issue template (`task.md`) and registered it in `.github/ISSUE_TEMPLATE/config.yml` to track maintenance or remedial work that is not a bug or feature. [[1]](diffhunk://#diff-f91a41a5c026cae62f7b10e1de060b93e628f85decc2639079cc055a91824912R1-R16) [[2]](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2R19-R23)
* Defined a new `task` label in `.github/labels.yml` to categorize issues and PRs related to maintenance tasks.
* Introduced a `sync-labels.yml` GitHub Actions workflow to automatically synchronize labels from `labels.yml` with the repository, ensuring consistency.

**Documentation Updates**

* Updated `CONTRIBUTING.md` to explain when and how to use the new Task issue template, including required information such as scope, acceptance criteria, impact/risk, and validation steps.
* Clarified in `CONTRIBUTING.md` that PRs should link to the relevant issue type, including Bug, Feature, Workflow Gap, or Task.

**Pull Request Workflow Improvements**

* Enhanced the PR template to support the new Task type, added a "Type of Change" checklist, and included additional fields for impact/risk and validation steps to improve review quality. [[1]](diffhunk://#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35L9-R10) [[2]](diffhunk://#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35R19-R39)# 