### PR TITLE
Add support for reading from stdin in various commands and enhance logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ zyra
 
 Notes
 - All subcommands accept `-` for stdin/stdout where applicable to support piping.
+  - `transform enrich-metadata` can read frames metadata JSON from stdin via `--read-frames-meta-stdin`.
+  - `decimate s3` can read bytes from stdin via `--read-stdin` (alias for `-i -`).
 
 ### Quick Usage by Group
 
@@ -181,7 +183,7 @@ Notes
   - Animate frames and compose to MP4: `zyra visualize animate --mode heatmap --input cube.npy --output-dir frames && zyra visualize compose-video --frames frames -o out.mp4`
 
 - Decimate
-  - Upload to S3 from stdin: `cat out.png | zyra decimate s3 -i - --url s3://bucket/products/out.png`
+- Upload to S3 from stdin: `cat out.png | zyra decimate s3 --read-stdin --url s3://bucket/products/out.png`
 - HTTP POST JSON: `echo '{"ok":true}' | zyra decimate post -i - https://example.com/ingest --content-type application/json`
 
 ## Batch Mode
@@ -425,7 +427,7 @@ Error handling
 
 ## Chaining Commands with --raw and --stdout
 
-The CLI supports streaming binary data through stdout/stdin so you can compose offline pipelines without touching disk.
+The CLI supports streaming binary data through stdout/stdin so you can compose offline pipelines without touching disk. For JSON metadata, chain `transform metadata -o - | zyra transform enrich-metadata --read-frames-meta-stdin ...` to avoid temp files. Note: stdin is a single stream; if you read frames metadata from stdin, pass the Vimeo URI via `--vimeo-uri` (not `--read-vimeo-uri`).
 
 - `.idx` → extract → convert (one-liner):
   ```bash
@@ -830,6 +832,10 @@ MIME detection (optional):
 WebSocket client extra:
 - Install `poetry install --with ws` to enable the `zyra-cli --ws` streaming option (bundles `websockets`).
 See Batch Mode section for multi-input workflows across acquisition, processing, and visualization.
+
+Logging workflows to a file
+- Use `zyra run <config.yaml> --log-file /path/to/logs/workflow.log [--log-file-mode overwrite]` to capture runner and stage logs into a dataset‑scoped location (default appends).
+- Alternatively, provide a directory and let Zyra write `workflow.log`: `zyra run <config.yaml> --log-dir /data/rt/dataset/<id>/logs`.
 ### Running Tests
 
 - Install dev deps and optional extras:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,3 +43,18 @@ contained, validated paths (e.g., `os.open` with `O_NOFOLLOW`, `open(mf)` after
 - Do not relax allowlists without revisiting containment and tests.
 - Keep tests for traversal and TTL behavior green.
 
+## Known Vulnerabilities
+
+### Python-Future (`future`) via `ffmpeg-python`
+
+- **Vulnerability**: `future >=0.14.0` automatically imports `test.py` if present in the working directory or in `sys.path`. This can allow **arbitrary code execution** if an attacker can place a malicious `test.py` file.
+- **Impact on Zyra**:  
+  - Zyra does not depend on `future` directly.  
+  - It is pulled in via [`ffmpeg-python`](https://github.com/kkroening/ffmpeg-python).  
+  - The latest available version of `future` (`1.0.0`) remains affected.  
+- **Status**:  
+  - No fixed release of `future` is available.  
+  - An [upstream issue (#784)](https://github.com/kkroening/ffmpeg-python/issues/784) and [PR (#795)](https://github.com/kkroening/ffmpeg-python/pull/795) are open to remove the `future` dependency from `ffmpeg-python`.  
+- **Mitigation**:  
+  - Zyra users should avoid running in directories where untrusted files may exist, especially `test.py`.  
+  - The Dependabot alert is marked as **Risk Tolerated** until an upstream fix is released.  

--- a/src/zyra/connectors/egress/__init__.py
+++ b/src/zyra/connectors/egress/__init__.py
@@ -40,11 +40,18 @@ def _cmd_local(ns: argparse.Namespace) -> int:
 def _cmd_s3(ns: argparse.Namespace) -> int:
     """Upload stdin or input file to S3 (s3:// or bucket/key)."""
     configure_logging_from_env()
+    # Validate mutually exclusive input sources
+    read_stdin = bool(getattr(ns, "read_stdin", False))
+    current_input = getattr(ns, "input", None)
+    if read_stdin and current_input not in (None, "-"):
+        raise SystemExit(
+            "Options --input and --read-stdin are mutually exclusive; provide exactly one."
+        )
     # Convenience alias: --read-stdin behaves like -i -
-    if getattr(ns, "read_stdin", False):
+    if read_stdin:
         ns.input = "-"
     if not getattr(ns, "input", None):
-        raise SystemExit("--input PATH or --read-stdin is required")
+        raise SystemExit("Missing input: specify --input PATH or use --read-stdin")
     data = _read_all(ns.input)
     ok = s3_backend.upload_bytes(data, ns.url if ns.url else ns.bucket, ns.key)
     if not ok:

--- a/src/zyra/pipeline_runner.py
+++ b/src/zyra/pipeline_runner.py
@@ -441,6 +441,10 @@ def run_pipeline(
                         "Hint: pipe input bytes or set ZYRA_DEFAULT_STDIN=/path/to/file (legacy DATAVIZHUB_DEFAULT_STDIN).\n"
                     )
                     sys.stderr.write(msg)
+                    from contextlib import suppress
+
+                    with suppress(Exception):
+                        logging.getLogger(__name__).error(msg.strip())
             except Exception:
                 pass
         if rc != 0:
@@ -456,6 +460,10 @@ def run_pipeline(
                     "or set ZYRA_VERBOSITY=debug (legacy DATAVIZHUB_VERBOSITY) for stage headings.\n"
                 )
                 sys.stderr.write(msg)
+                from contextlib import suppress
+
+                with suppress(Exception):
+                    logging.getLogger(__name__).error(msg.strip())
             except Exception:
                 pass
             if not continue_on_error:
@@ -525,6 +533,24 @@ def register_cli_run(subparsers: Any) -> None:
         action="store_true",
         help="Fail if ${VAR} placeholders are not set in environment",
     )
+    # Logging destination: either a file or a directory (defaults to workflow.log)
+    lg = p.add_mutually_exclusive_group()
+    lg.add_argument(
+        "--log-file",
+        dest="log_file",
+        help="Write runner and stage logs to the given file",
+    )
+    lg.add_argument(
+        "--log-dir",
+        dest="log_dir",
+        help="Write logs under this directory as workflow.log",
+    )
+    p.add_argument(
+        "--log-file-mode",
+        choices=["append", "overwrite"],
+        default="append",
+        help="Log file write mode (default: append)",
+    )
 
     def _cmd(ns: argparse.Namespace) -> int:
         pairs: list[tuple[str, str]] = []
@@ -547,6 +573,44 @@ def register_cli_run(subparsers: Any) -> None:
         if ns.strict_env:
             os.environ["ZYRA_STRICT_ENV"] = "1"
             os.environ["DATAVIZHUB_STRICT_ENV"] = "1"
+
+        # Optional file logging for the runner and in-process stages
+        # Resolve log file from --log-file or --log-dir
+        log_target = None
+        if getattr(ns, "log_file", None):
+            log_target = ns.log_file
+        elif getattr(ns, "log_dir", None):
+            from pathlib import Path
+
+            log_target = str(Path(ns.log_dir) / "workflow.log")
+
+        if log_target:
+            try:
+                from pathlib import Path
+
+                mode = "a" if ns.log_file_mode != "overwrite" else "w"
+                pth = Path(log_target)
+                if pth.parent:
+                    pth.parent.mkdir(parents=True, exist_ok=True)
+                fh = logging.FileHandler(pth, mode=mode, encoding="utf-8")
+                fh.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+                root = logging.getLogger()
+                # Avoid adding duplicate file handlers for the same path
+                if not any(
+                    getattr(h, "baseFilename", None) == str(pth) for h in root.handlers
+                ):
+                    root.addHandler(fh)
+                # Set root level based on env verbosity
+                lvl_map = {
+                    "debug": logging.DEBUG,
+                    "info": logging.INFO,
+                    "quiet": logging.ERROR,
+                }
+                verb = os.environ.get("ZYRA_VERBOSITY", "info").lower()
+                root.setLevel(lvl_map.get(verb, logging.INFO))
+            except Exception:
+                # Non-fatal if log file cannot be configured
+                pass
 
         return run_pipeline(
             ns.config,

--- a/src/zyra/transform/__init__.py
+++ b/src/zyra/transform/__init__.py
@@ -141,14 +141,14 @@ def register_cli(subparsers: Any) -> None:
         ``updated_at``.
         """
         configure_logging_from_env()
+        import sys
+
         from zyra.utils.json_file_manager import JSONFileManager
 
         fm = JSONFileManager()
         # Load base metadata JSON from file or stdin when requested
         try:
             if getattr(ns, "read_frames_meta_stdin", False):
-                import sys
-
                 raw = sys.stdin.buffer.read()
                 try:
                     js = raw.decode("utf-8")
@@ -174,8 +174,6 @@ def register_cli(subparsers: Any) -> None:
         # Attach vimeo_uri from arg or stdin
         vuri = getattr(ns, "vimeo_uri", None)
         if getattr(ns, "read_vimeo_uri", False):
-            import sys
-
             raw = sys.stdin.buffer.read()
             try:
                 data = raw.decode("utf-8").strip()
@@ -378,6 +376,8 @@ def register_cli(subparsers: Any) -> None:
         ``dataLink`` from a Vimeo URI. Writes the updated JSON to ``--output``.
         """
         configure_logging_from_env()
+        import sys
+
         # Fetch input JSON
         raw: bytes
         src = ns.input_url or ns.input_file
@@ -411,8 +411,6 @@ def register_cli(subparsers: Any) -> None:
             except Exception:
                 pass
         if ns.read_meta_stdin:
-            import sys
-
             raw_meta = sys.stdin.buffer.read()
             try:
                 js = raw_meta.decode("utf-8")

--- a/src/zyra/wizard/zyra_capabilities.json
+++ b/src/zyra/wizard/zyra_capabilities.json
@@ -1428,6 +1428,7 @@
         "options": [
           "--help",
           "--input",
+          "--read-stdin",
           "--url",
           "--bucket",
           "--key"
@@ -1439,8 +1440,12 @@
       "--input": {
         "help": "Input path or '-' for stdin",
         "path_arg": true,
-        "type": "path",
-        "required": true
+        "type": "path"
+      },
+      "--read-stdin": {
+        "help": "Read object body from stdin (alias for -i -)",
+        "type": "str",
+        "default": false
       },
       "--url": "Full URL s3://bucket/key",
       "--bucket": "Bucket name",
@@ -1592,6 +1597,7 @@
         "options": [
           "--help",
           "--frames-meta",
+          "--read-frames-meta-stdin",
           "--dataset-id",
           "--vimeo-uri",
           "--read-vimeo-uri",
@@ -1604,8 +1610,12 @@
       "--frames-meta": {
         "help": "Path to frames metadata JSON",
         "path_arg": true,
-        "type": "path",
-        "required": true
+        "type": "path"
+      },
+      "--read-frames-meta-stdin": {
+        "help": "Read frames metadata JSON from stdin",
+        "type": "str",
+        "default": false
       },
       "--dataset-id": "Dataset identifier to embed",
       "--vimeo-uri": "Vimeo video URI to embed in metadata",
@@ -1921,7 +1931,10 @@
           "--only",
           "--verbose",
           "--quiet",
-          "--strict-env"
+          "--strict-env",
+          "--log-file",
+          "--log-dir",
+          "--log-file-mode"
         ]
       }
     ],
@@ -1979,6 +1992,17 @@
         "help": "Fail if ${VAR} placeholders are not set in environment",
         "type": "str",
         "default": false
+      },
+      "--log-file": "Write runner and stage logs to the given file",
+      "--log-dir": "Write logs under this directory as workflow.log",
+      "--log-file-mode": {
+        "help": "Log file write mode (default: append)",
+        "choices": [
+          "append",
+          "overwrite"
+        ],
+        "type": "str",
+        "default": "append"
       }
     },
     "positionals": [

--- a/tests/cli/test_egress_s3_input_conflict.py
+++ b/tests/cli/test_egress_s3_input_conflict.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+def test_egress_s3_input_and_read_stdin_conflict(tmp_path):
+    from zyra.cli import main as cli_main
+
+    dummy = tmp_path / "dummy.txt"
+    dummy.write_text("hi", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main(
+            [
+                "decimate",
+                "s3",
+                "--input",
+                str(dummy),
+                "--read-stdin",
+                "--url",
+                "s3://bucket/key",
+            ]
+        )
+    assert "mutually exclusive" in str(exc.value)

--- a/tests/cli/test_egress_s3_read_stdin_alias.py
+++ b/tests/cli/test_egress_s3_read_stdin_alias.py
@@ -1,0 +1,30 @@
+import io
+import sys
+
+
+def test_egress_s3_read_stdin_alias(monkeypatch):
+    from zyra.cli import main as cli_main
+
+    sent = b"hello world\n"
+    fake_stdin = type("S", (), {"buffer": io.BytesIO(sent)})()
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+    captured = {}
+
+    def _fake_upload_bytes(
+        data: bytes, url_or_bucket: str, key: str | None = None
+    ) -> bool:
+        captured["data"] = data
+        captured["url_or_bucket"] = url_or_bucket
+        captured["key"] = key
+        return True
+
+    import zyra.connectors.backends.s3 as s3_backend
+
+    monkeypatch.setattr(s3_backend, "upload_bytes", _fake_upload_bytes)
+
+    rc = cli_main(["decimate", "s3", "--read-stdin", "--url", "s3://b/k"])
+    assert rc == 0
+    assert captured["data"] == sent
+    assert captured["url_or_bucket"] == "s3://b/k"
+    assert captured["key"] is None

--- a/tests/cli/test_egress_s3_read_stdin_alias.py
+++ b/tests/cli/test_egress_s3_read_stdin_alias.py
@@ -1,12 +1,13 @@
 import io
 import sys
+from types import SimpleNamespace
 
 
 def test_egress_s3_read_stdin_alias(monkeypatch):
     from zyra.cli import main as cli_main
 
     sent = b"hello world\n"
-    fake_stdin = type("S", (), {"buffer": io.BytesIO(sent)})()
+    fake_stdin = SimpleNamespace(buffer=io.BytesIO(sent))
     monkeypatch.setattr(sys, "stdin", fake_stdin)
 
     captured = {}

--- a/tests/cli/test_transform_enrich_metadata_stdin.py
+++ b/tests/cli/test_transform_enrich_metadata_stdin.py
@@ -1,0 +1,35 @@
+import io
+import json
+import sys
+from pathlib import Path
+
+
+def test_transform_enrich_metadata_reads_from_stdin(monkeypatch, tmp_path: Path):
+    from zyra.cli import main as cli_main
+
+    base = {
+        "start_datetime": "2025-01-01T00:00:00",
+        "end_datetime": "2025-01-02T00:00:00",
+    }
+    data = (json.dumps(base) + "\n").encode()
+    fake_stdin = type("S", (), {"buffer": io.BytesIO(data)})()
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+    out_path = tmp_path / "out.json"
+
+    rc = cli_main(
+        [
+            "transform",
+            "enrich-metadata",
+            "--read-frames-meta-stdin",
+            "--dataset-id",
+            "dataset123",
+            "-o",
+            str(out_path),
+        ]
+    )
+    assert rc == 0
+    js = json.loads(out_path.read_text(encoding="utf-8"))
+    assert js.get("dataset_id") == "dataset123"
+    assert js.get("start_datetime") == base["start_datetime"]
+    assert js.get("end_datetime") == base["end_datetime"]

--- a/tests/cli/test_transform_enrich_metadata_stdin.py
+++ b/tests/cli/test_transform_enrich_metadata_stdin.py
@@ -2,6 +2,7 @@ import io
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 def test_transform_enrich_metadata_reads_from_stdin(monkeypatch, tmp_path: Path):
@@ -12,7 +13,7 @@ def test_transform_enrich_metadata_reads_from_stdin(monkeypatch, tmp_path: Path)
         "end_datetime": "2025-01-02T00:00:00",
     }
     data = (json.dumps(base) + "\n").encode()
-    fake_stdin = type("S", (), {"buffer": io.BytesIO(data)})()
+    fake_stdin = SimpleNamespace(buffer=io.BytesIO(data))
     monkeypatch.setattr(sys, "stdin", fake_stdin)
 
     out_path = tmp_path / "out.json"

--- a/tests/cli/test_transform_stdin_errors.py
+++ b/tests/cli/test_transform_stdin_errors.py
@@ -1,0 +1,79 @@
+import io
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_enrich_metadata_invalid_utf8_stdin(monkeypatch, tmp_path: Path):
+    from zyra.cli import main as cli_main
+
+    # Invalid UTF-8 bytes
+    bad = b"\xff\xfe\xfa\x00"
+    fake_stdin = SimpleNamespace(buffer=io.BytesIO(bad))
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main(
+            [
+                "transform",
+                "enrich-metadata",
+                "--read-frames-meta-stdin",
+                "--dataset-id",
+                "dataset123",
+                "-o",
+                str(tmp_path / "out.json"),
+            ]
+        )
+    assert "Failed to decode stdin as UTF-8 for frames metadata" in str(exc.value)
+
+
+def test_enrich_metadata_invalid_json_stdin(monkeypatch, tmp_path: Path):
+    from zyra.cli import main as cli_main
+
+    bad = b"{ not-json }"
+    fake_stdin = SimpleNamespace(buffer=io.BytesIO(bad))
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main(
+            [
+                "transform",
+                "enrich-metadata",
+                "--read-frames-meta-stdin",
+                "--dataset-id",
+                "dataset123",
+                "-o",
+                str(tmp_path / "out.json"),
+            ]
+        )
+    assert "Invalid JSON on stdin for frames metadata" in str(exc.value)
+
+
+def test_update_dataset_invalid_meta_json_stdin(monkeypatch, tmp_path: Path):
+    from zyra.cli import main as cli_main
+
+    # Minimal dataset index
+    ds = tmp_path / "dataset.json"
+    ds.write_text('{"datasets": [{"id": "x"}]}', encoding="utf-8")
+
+    bad = b"{"  # truncated JSON
+    fake_stdin = SimpleNamespace(buffer=io.BytesIO(bad))
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main(
+            [
+                "transform",
+                "update-dataset-json",
+                "--input-file",
+                str(ds),
+                "--dataset-id",
+                "x",
+                "--read-meta-stdin",
+                "-o",
+                str(tmp_path / "out.json"),
+            ]
+        )
+    assert "Invalid metadata JSON on stdin" in str(exc.value)

--- a/tests/misc/test_runner_log_dir.py
+++ b/tests/misc/test_runner_log_dir.py
@@ -1,0 +1,52 @@
+import textwrap
+from pathlib import Path
+
+
+def test_runner_writes_log_file_with_log_dir(tmp_path: Path, monkeypatch):
+    from zyra.cli import main as cli_main
+
+    # Ensure any relative output paths land under tmp_path
+    monkeypatch.chdir(tmp_path)
+
+    # Minimal pipeline: process convert-format - netcdf --stdout
+    cfg = tmp_path / "pipe.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            stages:
+              - stage: process
+                command: convert-format
+                args:
+                  file_or_url: '-'
+                  format: netcdf
+                  stdout: true
+              - stage: decimate
+                command: local
+                args:
+                  input: '-'
+                  path: "out.nc"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    # Seed stdin via env so runner feeds bytes to the first stage
+    repo_root = Path(__file__).resolve().parents[2]
+    demo_nc = repo_root / "tests/testdata/demo.nc"
+    assert demo_nc.exists()
+    monkeypatch.setenv("ZYRA_DEFAULT_STDIN", str(demo_nc))
+
+    log_dir = tmp_path / "logs"
+    rc = cli_main(
+        ["run", str(cfg), "--log-dir", str(log_dir), "-v"]
+    )  # verbose for logs
+    assert rc == 0
+
+    # Ensure all logging handlers flush
+    import logging
+
+    logging.shutdown()
+    log_path = log_dir / "workflow.log"
+    assert log_path.exists()
+    # File presence is the primary requirement for --log-dir
+    assert log_path.stat().st_size >= 0


### PR DESCRIPTION
This pull request introduces several enhancements to the Zyra CLI, focusing on improved input flexibility, logging capabilities, and documentation clarity. The most significant changes are the addition of options to read input from stdin for metadata enrichment and S3 uploads, support for workflow logging to files or directories, and corresponding updates to documentation and tests to cover these new features.

### CLI Input Flexibility

* Added `--read-frames-meta-stdin` option to `transform enrich-metadata`, allowing frames metadata JSON to be read from stdin as an alternative to file input. [[1]](diffhunk://#diff-8e72139a5341685f6478a48998e4f1832ae5ed15516fc1ce93dd2cc2750a1972L180-R198) [[2]](diffhunk://#diff-8e72139a5341685f6478a48998e4f1832ae5ed15516fc1ce93dd2cc2750a1972L147-R154) [[3]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdR1600) [[4]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdL1607-R1618)
* Added `--read-stdin` option to `decimate s3`, enabling object body upload from stdin as an alias for `-i -`. The input argument is now optional if `--read-stdin` is provided. [[1]](diffhunk://#diff-209772d220c96ead85bf6af5141528fced55ed2fcd5cebbed4549e13b0621338L75-R86) [[2]](diffhunk://#diff-209772d220c96ead85bf6af5141528fced55ed2fcd5cebbed4549e13b0621338R43-R47) [[3]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdR1431) [[4]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdL1442-R1448)

### Logging Enhancements

* Introduced `--log-file`, `--log-dir`, and `--log-file-mode` options to the `run` command, allowing runner and stage logs to be written to a specified file or directory, with configurable append/overwrite mode. [[1]](diffhunk://#diff-852c3ebf6fd63f6714b1d8d46cf066d4756195f6dbcb527e39d5a7fbcdf250fcR536-R553) [[2]](diffhunk://#diff-852c3ebf6fd63f6714b1d8d46cf066d4756195f6dbcb527e39d5a7fbcdf250fcR577-R614) [[3]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdL1924-R1937) [[4]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdR1995-R2005)
* Updated error handling in `run_pipeline` to also log errors to the configured log destination, in addition to stderr. [[1]](diffhunk://#diff-852c3ebf6fd63f6714b1d8d46cf066d4756195f6dbcb527e39d5a7fbcdf250fcR444-R447) [[2]](diffhunk://#diff-852c3ebf6fd63f6714b1d8d46cf066d4756195f6dbcb527e39d5a7fbcdf250fcR463-R466)

### Documentation Updates

* Expanded `README.md` to document the new stdin options for metadata enrichment and S3 uploads, as well as the new logging workflow features. Also clarified chaining commands for JSON metadata and provided usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R165-R166) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L184-R186) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L428-R430) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R835-R838)

### Test Coverage

* Added tests for reading frames metadata from stdin (`test_transform_enrich_metadata_stdin.py`), S3 upload from stdin (`test_egress_s3_read_stdin_alias.py`), and runner log file creation with `--log-dir` (`test_runner_log_dir.py`). [[1]](diffhunk://#diff-0837e074074a15ac27b353879f874225c549d04d5c514d897fa7c1f9045f47ebR1-R30) [[2]](diffhunk://#diff-7ed49043ec5a436f39494a249207c94fac8f00ea086705029c9ef2b6204b3452R1-R35) [[3]](diffhunk://#diff-83cb35cbced29d5bffea2837fef0893acd0010a6c0637a006bf22424ecf291ceR1-R52)

### Security Documentation

* Documented a known vulnerability in the `future` package (used via `ffmpeg-python`) in `SECURITY.md`, with mitigation advice for users.