### PR TITLE
Add new `pad-missing` command for generating placeholder frames for missing timestamps

### DIFF
--- a/docs/source/api/zyra.processing.rst
+++ b/docs/source/api/zyra.processing.rst
@@ -14,6 +14,11 @@ Modules
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: zyra.processing.pad_missing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: zyra.processing.video_processor
    :members:
    :undoc-members:

--- a/src/zyra/processing/README.md
+++ b/src/zyra/processing/README.md
@@ -5,6 +5,7 @@ Commands
 - `decode-grib2` — Decode GRIB2 and print metadata (supports cfgrib/pygrib/wgrib2 backends).
 - `extract-variable` — Extract a variable from a dataset and write to NetCDF.
 - `convert-format` — Convert decoded data to NetCDF/GeoTIFF (when supported).
+- `pad-missing` — Generate placeholder frames for missing timestamps using transform metadata.
 - `audio-transcode` — Transcode audio (wav/mp3/ogg) via ffmpeg.
 - `audio-metadata` — Print audio metadata via ffprobe.
 
@@ -57,6 +58,20 @@ GRIB2
 - Decode: `zyra process decode-grib2 input.grib2`
 - Backends: `--backend cfgrib|pygrib|wgrib2`
 - Convert: `zyra process convert-format input.grib2 netcdf -o out.nc`
+
+pad-missing
+- Metadata: `--frames-meta frames_meta.json` (from `transform scan-frames`)
+- Stdin metadata: `--read-frames-meta-stdin` (pipe JSON from `transform scan-frames`)
+- Output: `--output-dir data/padded_frames`
+- Modes: `--fill-mode blank|solid|basemap|nearest`
+- Basemap/color: `--basemap pkg:zyra.assets/images/earth_vegetation.jpg` or `--basemap "#202020"`
+- Indicators: `--indicator watermark:MISSING` or `--indicator badge:pkg:zyra.assets/images/nearest.png`
+- Reports: `--json-report _work/images/${DATASET_NAME}/metadata/pad-missing-report.json`
+
+Examples
+- Basemap placeholders: `zyra process pad-missing --frames-meta frames_meta.json --fill-mode basemap --basemap pkg:zyra.assets/images/earth_vegetation.jpg --output-dir data/padded`
+- Nearest copy with watermark + report: `zyra process pad-missing --frames-meta frames_meta.json --fill-mode nearest --indicator watermark:ESTIMATED --json-report data/padded/pad-missing-report.json --output-dir data/padded`
+- Pipeline piping example: `zyra transform scan-frames --frames-dir frames -o - | zyra process pad-missing --read-frames-meta-stdin --output-dir frames_padded`
 
 Audio
 - Transcode: `zyra process audio-transcode input.ogg --to wav -o out.wav`

--- a/src/zyra/processing/pad_missing.py
+++ b/src/zyra/processing/pad_missing.py
@@ -312,7 +312,8 @@ def _apply_watermark(img: PILImage.Image, text: str | None) -> PILImage.Image:
         text_width = bbox[2] - bbox[0]
         text_height = bbox[3] - bbox[1]
     except Exception:
-        text_width, text_height = font.getsize(text)
+        mask = font.getmask(text)
+        text_width, text_height = mask.size
     margin = max(8, width // 100)
     x = width - text_width - margin
     y = height - text_height - margin

--- a/src/zyra/processing/pad_missing.py
+++ b/src/zyra/processing/pad_missing.py
@@ -479,11 +479,18 @@ def pad_missing_frames(
                     base = donor_img.convert(target_mode or donor_img.mode)
             img = base
             if indicator_spec:
-                img = _apply_indicator(base, indicator_spec)
+                img = _apply_indicator(img, indicator_spec)
             _save_image(img, target, target_mode)
-            if img is not base and hasattr(base, "close"):
+            seen: set[int] = set()
+            for candidate in (img, base):
+                if candidate is None or not hasattr(candidate, "close"):
+                    continue
+                obj_id = id(candidate)
+                if obj_id in seen:
+                    continue
+                seen.add(obj_id)
                 with contextlib.suppress(Exception):
-                    base.close()
+                    candidate.close()
         created.append(target)
         logging.debug("Created placeholder frame '%s'", target)
     if dry_run:

--- a/src/zyra/processing/pad_missing.py
+++ b/src/zyra/processing/pad_missing.py
@@ -1,0 +1,508 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fill missing frame timestamps with synthetic images or copies.
+
+This module powers the ``zyra process pad-missing`` CLI. It consumes the JSON
+summary produced by ``zyra transform metadata``/``scan-frames`` to detect gaps
+and produces placeholder frames so downstream animation steps receive a
+contiguous chronology.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import re
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+from PIL import Image, ImageColor, ImageDraw, ImageFont, ImageOps
+
+from zyra.utils.date_manager import DateManager
+from zyra.utils.io_utils import open_input
+
+try:  # Optional dependency for basemap resolution reused from visualization
+    from zyra.visualization.cli_utils import resolve_basemap_ref
+except Exception:  # pragma: no cover - keep CLI usable without visualization extras
+    resolve_basemap_ref = None  # type: ignore[assignment]
+
+
+SUPPORTED_EXTENSIONS = (".png", ".jpg", ".jpeg", ".gif", ".bmp", ".dds")
+DEFAULT_SIZE = (1920, 1080)
+DEFAULT_MODE = "RGBA"
+
+
+@dataclass(frozen=True)
+class FrameRecord:
+    """Existing frame entry tracked by timestamp."""
+
+    timestamp: datetime
+    path: Path
+
+
+class FramesCatalog:
+    """Map timestamps to existing frame paths and derive naming conventions."""
+
+    def __init__(
+        self,
+        frames_dir: str,
+        *,
+        pattern: str | None = None,
+        datetime_format: str | None = None,
+    ) -> None:
+        self.frames_root = Path(frames_dir).expanduser()
+        if not self.frames_root.exists() or not self.frames_root.is_dir():
+            raise FileNotFoundError(f"Frames directory not found: {frames_dir}")
+        self.pattern = pattern
+        self.datetime_format = datetime_format
+        self._records: list[FrameRecord] = []
+        self._timestamp_to_path: dict[str, Path] = {}
+        self._suffix_counter: Counter[str] = Counter()
+        self._prefix = ""
+        self._suffix = ""
+        self._scan()
+
+    # ------------------------------------------------------------------
+    def _scan(self) -> None:
+        names = [f for f in self.frames_root.iterdir() if f.is_file()]
+        if self.pattern:
+            rx = re.compile(self.pattern)
+            names = [p for p in names if rx.search(p.name)]
+        else:
+            names = [p for p in names if p.suffix.lower() in SUPPORTED_EXTENSIONS]
+        if not names:
+            logging.warning("No frame images found in '%s'", self.frames_root)
+        dm = DateManager([self.datetime_format] if self.datetime_format else None)
+        fmt_regex = (
+            dm.datetime_format_to_regex(self.datetime_format)
+            if self.datetime_format
+            else None
+        )
+        template_prefix = None
+        template_suffix = None
+        for path in sorted(names):
+            name = path.name
+            ts = None
+            if self.datetime_format and fmt_regex:
+                m = re.search(fmt_regex, name)
+                if m:
+                    try:
+                        ts = datetime.strptime(m.group(), self.datetime_format)
+                        if template_prefix is None:
+                            template_prefix = name[: m.start()]
+                            template_suffix = name[m.end() :]
+                    except Exception:
+                        ts = None
+            if ts is None:
+                iso = dm.extract_date_time(name)
+                if iso:
+                    try:
+                        ts = datetime.fromisoformat(iso)
+                    except ValueError:
+                        ts = None
+            if ts is None:
+                continue
+            rec = FrameRecord(timestamp=ts, path=path)
+            key = ts.isoformat()
+            self._records.append(rec)
+            self._timestamp_to_path[key] = path
+            self._suffix_counter[path.suffix.lower()] += 1
+        self._records.sort(key=lambda r: r.timestamp)
+        if template_prefix is not None:
+            self._prefix = template_prefix
+            self._suffix = template_suffix or ""
+        else:
+            self._prefix = ""
+            self._suffix = ""
+
+    # ------------------------------------------------------------------
+    def has_timestamp(self, ts: datetime) -> bool:
+        return ts.isoformat() in self._timestamp_to_path
+
+    def get(self, ts: datetime) -> Path | None:
+        return self._timestamp_to_path.get(ts.isoformat())
+
+    def nearest(self, ts: datetime) -> Path | None:
+        if not self._records:
+            return None
+        targets = [rec.timestamp for rec in self._records]
+        pos = self._bisect(targets, ts)
+        candidates: list[FrameRecord] = []
+        if pos > 0:
+            candidates.append(self._records[pos - 1])
+        if pos < len(self._records):
+            candidates.append(self._records[pos])
+        if not candidates:
+            return None
+        best = min(candidates, key=lambda rec: abs(rec.timestamp - ts))
+        return best.path
+
+    @staticmethod
+    def _bisect(items: Sequence[datetime], value: datetime) -> int:
+        lo, hi = 0, len(items)
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if items[mid] < value:
+                lo = mid + 1
+            else:
+                hi = mid
+        return lo
+
+    @property
+    def extension(self) -> str:
+        if not self._suffix_counter:
+            return ".png"
+        return self._suffix_counter.most_common(1)[0][0]
+
+    def filename_for(self, ts: datetime) -> str:
+        if self.datetime_format:
+            stamp = ts.strftime(self.datetime_format)
+            return f"{self._prefix}{stamp}{self._suffix}"
+        return f"{ts.isoformat()}{self.extension}"
+
+    @property
+    def sample_image_path(self) -> Path | None:
+        return self._records[0].path if self._records else None
+
+    @property
+    def record_count(self) -> int:
+        return len(self._records)
+
+
+@dataclass
+class IndicatorSpec:
+    kind: str
+    value: str | None = None
+
+
+def parse_indicator(spec: str | None) -> IndicatorSpec | None:
+    if not spec:
+        return None
+    token = spec.strip()
+    if not token:
+        return None
+    if ":" not in token:
+        raise ValueError("Indicator must use 'kind:value' form")
+    kind, value = token.split(":", 1)
+    kind = kind.strip().lower()
+    value = value.strip()
+    if kind not in {"watermark", "badge"}:
+        raise ValueError(f"Unsupported indicator '{kind}'")
+    if not value:
+        raise ValueError("Indicator value cannot be empty")
+    return IndicatorSpec(kind=kind, value=value)
+
+
+def _load_metadata(path_or_stream: str, read_stdin: bool = False) -> dict:
+    target = "-" if read_stdin else path_or_stream
+    with open_input(target) as fp:
+        raw = fp.read()
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except Exception as exc:  # pragma: no cover - defensive decoding
+        raise ValueError(f"Failed to decode frames metadata: {exc}") from exc
+
+
+def _determine_canvas(catalog: FramesCatalog) -> tuple[tuple[int, int], str]:
+    sample_path = catalog.sample_image_path
+    if not sample_path or not sample_path.exists():
+        return DEFAULT_SIZE, DEFAULT_MODE
+    try:
+        with Image.open(sample_path) as img:
+            return img.size, img.mode
+    except Exception:
+        return DEFAULT_SIZE, DEFAULT_MODE
+
+
+def _save_image(image: Image.Image, destination: Path, target_mode: str | None) -> None:
+    out = image
+    converted = None
+    if target_mode and out.mode != target_mode:
+        converted = out.convert(target_mode)
+        out = converted
+    try:
+        out.save(destination)
+    finally:
+        if converted is not None:
+            with contextlib.suppress(Exception):
+                converted.close()
+
+
+def _build_blank(
+    mode: str, size: tuple[int, int], color: str | None = None
+) -> Image.Image:
+    if mode == "P":
+        mode = "RGBA"
+    fill = (0, 0, 0, 0) if "A" in mode and not color else None
+    if color:
+        try:
+            rgb = ImageColor.getcolor(color, mode if "A" not in mode else "RGBA")
+            if len(rgb) == 3 and "A" in mode:
+                rgb = (*rgb, 255)
+            fill = rgb
+        except ValueError as exc:
+            raise ValueError(f"Invalid color '{color}' for solid fill: {exc}") from exc
+    if fill is None:
+        fill = (0, 0, 0, 255) if "A" in mode else 0
+    return Image.new(mode if mode != "1" else "L", size, fill)
+
+
+def _load_basemap(basemap: str, size: tuple[int, int]) -> Image.Image:
+    if not basemap:
+        raise ValueError("--basemap is required for basemap fill mode")
+    path = basemap
+    guard = None
+    if resolve_basemap_ref:
+        resolved, guard = resolve_basemap_ref(basemap)
+        if resolved:
+            path = resolved
+    if not path:
+        raise ValueError(f"Could not resolve basemap reference '{basemap}'")
+    try:
+        with Image.open(path) as img:
+            img = img.convert("RGBA")
+            return ImageOps.fit(img, size, method=Image.BILINEAR)
+    finally:
+        if guard is not None:
+            with contextlib.suppress(Exception):
+                guard.close()
+
+
+def _apply_indicator(img: Image.Image, spec: IndicatorSpec) -> Image.Image:
+    if spec.kind == "watermark":
+        return _apply_watermark(img, spec.value)
+    if spec.kind == "badge":
+        return _apply_badge(img, spec.value)
+    return img
+
+
+def _apply_watermark(img: Image.Image, text: str | None) -> Image.Image:
+    if not text:
+        return img
+    out = img.copy()
+    draw = ImageDraw.Draw(out)
+    font = ImageFont.load_default()
+    width, height = out.size
+    try:
+        bbox = draw.textbbox((0, 0), text, font=font)
+        text_width = bbox[2] - bbox[0]
+        text_height = bbox[3] - bbox[1]
+    except Exception:
+        text_width, text_height = font.getsize(text)
+    margin = max(8, width // 100)
+    x = width - text_width - margin
+    y = height - text_height - margin
+    if "A" in out.mode:
+        box = Image.new(
+            "RGBA", (text_width + margin, text_height + margin), (0, 0, 0, 128)
+        )
+        out.alpha_composite(box, dest=(x - margin // 2, y - margin // 2))
+        draw = ImageDraw.Draw(out)
+        draw.text((x, y), text, font=font, fill=(255, 255, 255, 255))
+    else:
+        draw.rectangle(
+            [
+                (x - margin // 2, y - margin // 2),
+                (x + text_width + margin // 2, y + text_height + margin // 2),
+            ],
+            fill="black",
+        )
+        draw.text((x, y), text, font=font, fill="white")
+    return out
+
+
+def _apply_badge(img: Image.Image, badge_path: str | None) -> Image.Image:
+    if not badge_path:
+        return img
+    path = badge_path
+    guard = None
+    if resolve_basemap_ref:
+        resolved, guard = resolve_basemap_ref(badge_path)
+        if resolved:
+            path = resolved
+    out = img.copy()
+    try:
+        if not path:
+            raise ValueError(f"Could not resolve badge '{badge_path}'")
+        with Image.open(path) as badge:
+            badge = badge.convert("RGBA")
+            scale = 0.18  # badge covers ~18% of width
+            max_width = int(out.size[0] * scale)
+            if badge.size[0] > max_width:
+                ratio = max_width / badge.size[0]
+                new_size = (max_width, max(1, int(badge.size[1] * ratio)))
+                badge = badge.resize(new_size, resample=Image.BILINEAR)
+            pos = (
+                out.size[0] - badge.size[0] - 12,
+                out.size[1] - badge.size[1] - 12,
+            )
+            if "A" not in out.mode:
+                out = out.convert("RGBA")
+            out.alpha_composite(badge, dest=pos)
+            if img.mode != out.mode:
+                out = out.convert(img.mode)
+            return out
+    finally:
+        if guard:
+            with contextlib.suppress(Exception):
+                guard.close()
+    return out
+
+
+def _write_json_report(path: str, payload: dict[str, Any]) -> None:
+    report_path = Path(path)
+    if report_path.parent:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2) + "\n"
+    report_path.write_text(text, encoding="utf-8")
+
+
+def pad_missing_frames(
+    metadata_path: str,
+    *,
+    output_dir: str,
+    fill_mode: str,
+    basemap: str | None = None,
+    indicator: str | None = None,
+    overwrite: bool = False,
+    dry_run: bool = False,
+    json_report: str | None = None,
+    read_stdin: bool = False,
+) -> list[Path]:
+    """Pad missing frame timestamps according to the requested strategy."""
+    meta = _load_metadata(metadata_path, read_stdin)
+    frames_dir = meta.get("frames_dir")
+    if not frames_dir:
+        raise ValueError("Metadata must include 'frames_dir'")
+    missing = meta.get("missing_timestamps") or []
+    if not isinstance(missing, list):
+        raise ValueError("Metadata 'missing_timestamps' must be a list")
+    pattern = meta.get("pattern")
+    datetime_format = meta.get("datetime_format")
+    catalog = FramesCatalog(
+        frames_dir, pattern=pattern, datetime_format=datetime_format
+    )
+    size, mode = _determine_canvas(catalog)
+    indicator_spec = parse_indicator(indicator)
+    out_root = Path(output_dir).expanduser()
+    out_root.mkdir(parents=True, exist_ok=True)
+    created: list[Path] = []
+    planned: list[str] = []
+    skipped_existing: list[str] = []
+    fill_mode = (fill_mode or "blank").lower()
+    if fill_mode not in {"blank", "solid", "basemap", "nearest"}:
+        raise ValueError(f"Unsupported fill mode '{fill_mode}'")
+    # Pre-load reusable assets
+    basemap_img = None
+    if fill_mode == "solid":
+        basemap_img = _build_blank(mode, size, basemap or "#000000")
+    elif fill_mode == "basemap":
+        basemap_img = _load_basemap(basemap or "", size)
+    sorted_missing = sorted(
+        datetime.fromisoformat(ts) for ts in missing if isinstance(ts, str)
+    )
+    if not sorted_missing:
+        logging.info("No missing timestamps detected; nothing to do")
+    target_mode = mode
+    sample_name = catalog.filename_for(sorted_missing[0]) if sorted_missing else ""
+    ext = Path(sample_name).suffix.lower() if sample_name else catalog.extension
+    if ext in {".jpg", ".jpeg"}:
+        target_mode = "RGB"
+    elif not target_mode:
+        target_mode = DEFAULT_MODE
+    for ts in sorted_missing:
+        filename = catalog.filename_for(ts)
+        target = out_root / filename
+        if target.exists() and not overwrite:
+            logging.info(
+                "Skipping existing frame '%s' (use --overwrite to replace)", target
+            )
+            skipped_existing.append(str(target))
+            continue
+        if dry_run:
+            logging.info("[dry-run] would create '%s'", target)
+            planned.append(str(target))
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if fill_mode == "blank":
+            img = _build_blank(mode, size)
+            if indicator_spec:
+                img = _apply_indicator(img, indicator_spec)
+            _save_image(img, target, target_mode)
+        elif fill_mode == "solid":
+            img = (
+                basemap_img.copy() if basemap_img else _build_blank(mode, size, basemap)
+            )
+            if indicator_spec:
+                img = _apply_indicator(img, indicator_spec)
+            _save_image(img, target, target_mode)
+        elif fill_mode == "basemap":
+            if basemap_img is None:
+                raise ValueError("Failed to prepare basemap image")
+            img = basemap_img.copy()
+            if indicator_spec:
+                img = _apply_indicator(img, indicator_spec)
+            _save_image(img, target, target_mode)
+        elif fill_mode == "nearest":
+            donor = catalog.nearest(ts)
+            if not donor:
+                logging.warning("No donor frame available for %s; using blank", ts)
+                base = _build_blank(mode, size)
+            else:
+                with Image.open(donor) as donor_img:
+                    base = donor_img.convert(target_mode or donor_img.mode)
+            img = base
+            if indicator_spec:
+                img = _apply_indicator(base, indicator_spec)
+            _save_image(img, target, target_mode)
+            if img is not base and hasattr(base, "close"):
+                with contextlib.suppress(Exception):
+                    base.close()
+        created.append(target)
+        logging.debug("Created placeholder frame '%s'", target)
+    if dry_run:
+        logging.info(
+            "Dry run complete; %d frame(s) would be created in '%s'",
+            len(planned),
+            out_root,
+        )
+    else:
+        logging.info("Created %d placeholder frame(s) in '%s'", len(created), out_root)
+
+    if json_report:
+        try:
+            report_payload: dict[str, Any] = {
+                "status": "dry-run" if dry_run else "completed",
+                "metadata_path": metadata_path if not read_stdin else "-",
+                "frames_dir": str(frames_dir),
+                "output_dir": str(out_root),
+                "fill_mode": fill_mode,
+                "basemap": basemap,
+                "indicator": (
+                    {"kind": indicator_spec.kind, "value": indicator_spec.value}
+                    if indicator_spec
+                    else None
+                ),
+                "missing_requested": [ts.isoformat() for ts in sorted_missing],
+                "missing_count": len(sorted_missing),
+                "created_count": len(created),
+                "created_files": [str(p) for p in created],
+                "planned_count": len(planned),
+                "planned_files": planned,
+                "skipped_existing_count": len(skipped_existing),
+                "skipped_existing": skipped_existing,
+                "dry_run": dry_run,
+                "overwrite": overwrite,
+                "frames_existing_count": catalog.record_count,
+                "timestamp": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+            }
+            _write_json_report(json_report, report_payload)
+            logging.info("Wrote pad-missing report to '%s'", json_report)
+        except Exception as exc:  # pragma: no cover - best-effort reporting
+            logging.error(
+                "Failed to write pad-missing report '%s': %s", json_report, exc
+            )
+    return created

--- a/src/zyra/processing/pad_missing.py
+++ b/src/zyra/processing/pad_missing.py
@@ -130,9 +130,12 @@ class FramesCatalog:
             self._timestamp_to_path[key] = path
             self._suffix_counter[path.suffix.lower()] += 1
         self._records.sort(key=lambda r: r.timestamp)
-        if template_prefix is not None:
-            self._prefix = template_prefix
-            self._suffix = template_suffix or ""
+        self._apply_template_bounds(template_prefix, template_suffix)
+
+    def _apply_template_bounds(self, prefix: str | None, suffix: str | None) -> None:
+        if prefix is not None:
+            self._prefix = prefix
+            self._suffix = suffix or ""
         else:
             self._prefix = ""
             self._suffix = ""

--- a/src/zyra/transform/README.md
+++ b/src/zyra/transform/README.md
@@ -1,7 +1,7 @@
 # Transform
 
 Commands
-- `metadata` — Compute frames metadata JSON from a directory of images.
+- `metadata` — Compute frames metadata JSON from a directory of images (alias: `scan-frames`).
 - `enrich-metadata` — Enrich frames metadata JSON with dataset id, Vimeo URI, and timestamp.
 - `update-dataset-json` — Update dataset JSON fields from CLI args or another file.
 
@@ -13,4 +13,4 @@ metadata
 - Output: `-o out.json` or `-` for stdout
 
 Examples
-- `zyra transform metadata --frames-dir ./frames --pattern '\\.(png|jpg)$' --period-seconds 300 -o frames.json`
+- `zyra transform scan-frames --frames-dir ./frames --pattern '\\.(png|jpg)$' --period-seconds 300 -o frames.json`

--- a/src/zyra/wizard/zyra_capabilities.json
+++ b/src/zyra/wizard/zyra_capabilities.json
@@ -1521,6 +1521,93 @@
       "stdout": true
     }
   },
+  "process pad-missing": {
+    "description": "Read frames metadata JSON from 'transform metadata/scan-frames' and generate placeholder images for each missing timestamp using blank, solid color, basemap, or nearest-frame strategies.",
+    "doc": "Read frames metadata JSON from 'transform metadata/scan-frames' and generate placeholder images for each missing timestamp using blank, solid color, basemap, or nearest-frame strategies.",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--frames-meta",
+          "--read-frames-meta-stdin",
+          "--output-dir",
+          "--fill-mode",
+          "--basemap",
+          "--indicator",
+          "--overwrite",
+          "--dry-run",
+          "--json-report",
+          "--verbose",
+          "--quiet",
+          "--trace"
+        ]
+      }
+    ],
+    "options": {
+      "--help": "show this help message and exit",
+      "--frames-meta": {
+        "help": "Path to frames metadata JSON (from transform metadata/scan-frames)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--read-frames-meta-stdin": {
+        "help": "Read frames metadata JSON from stdin",
+        "type": "bool",
+        "default": false
+      },
+      "--output-dir": {
+        "help": "Directory where placeholder frames will be written",
+        "path_arg": true,
+        "type": "path",
+        "required": true
+      },
+      "--fill-mode": {
+        "help": "Strategy for filling gaps (default: blank)",
+        "choices": [
+          "blank",
+          "solid",
+          "basemap",
+          "nearest"
+        ],
+        "type": "str",
+        "default": "blank"
+      },
+      "--basemap": "Basemap image, package reference, or color (solid/basemap modes)",
+      "--indicator": "Optional overlay indicator, e.g., watermark:MISSING or badge:pkg:...",
+      "--overwrite": {
+        "help": "Replace existing files when output paths already exist",
+        "type": "bool",
+        "default": false
+      },
+      "--dry-run": {
+        "help": "Report planned outputs without writing files",
+        "type": "bool",
+        "default": false
+      },
+      "--json-report": "Optional path to write a JSON summary report",
+      "--verbose": {
+        "help": "Verbose logging for this command",
+        "type": "bool",
+        "default": false
+      },
+      "--quiet": {
+        "help": "Quiet logging for this command",
+        "type": "bool",
+        "default": false
+      },
+      "--trace": {
+        "help": "Shell-style trace of key steps and external commands",
+        "type": "bool",
+        "default": false
+      }
+    },
+    "positionals": [],
+    "domain": "process",
+    "args_schema": null,
+    "example_args": null
+  },
   "process api-json": {
     "description": "Read a JSON or NDJSON file/stream, select fields via dot paths, optionally flatten nested objects, explode arrays into multiple rows, and write CSV or JSONL.",
     "doc": "Read a JSON or NDJSON file/stream, select fields via dot paths, optionally flatten nested objects, explode arrays into multiple rows, and write CSV or JSONL.",
@@ -1761,6 +1848,67 @@
   "process metadata": {
     "description": "Scan a frames directory to compute start/end timestamps, counts, and missing frames on a cadence.",
     "doc": "Scan a frames directory to compute start/end timestamps, counts, and missing frames on a cadence.",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--frames-dir",
+          "--pattern",
+          "--datetime-format",
+          "--period-seconds",
+          "--output",
+          "--verbose",
+          "--quiet",
+          "--trace"
+        ]
+      }
+    ],
+    "options": {
+      "--help": "show this help message and exit",
+      "--frames-dir": {
+        "help": "Directory containing frames",
+        "path_arg": true,
+        "type": "path",
+        "required": true
+      },
+      "--pattern": "Regex filter for frame filenames",
+      "--datetime-format": "Datetime format used in filenames (e.g., %Y%m%d%H%M%S)",
+      "--period-seconds": {
+        "help": "Expected cadence to compute missing frames",
+        "type": "int"
+      },
+      "--output": {
+        "help": "Output path or '-' for stdout",
+        "path_arg": true,
+        "type": "path",
+        "default": "-"
+      },
+      "--verbose": {
+        "help": "Verbose logging for this command",
+        "type": "bool",
+        "default": false
+      },
+      "--quiet": {
+        "help": "Quiet logging for this command",
+        "type": "bool",
+        "default": false
+      },
+      "--trace": {
+        "help": "Shell-style trace of key steps and external commands",
+        "type": "bool",
+        "default": false
+      }
+    },
+    "positionals": [],
+    "domain": "process",
+    "args_schema": null,
+    "example_args": null
+  },
+  "process scan-frames": {
+    "description": "Alias of 'metadata'. Scan a frames directory and report timestamps, counts, and missing frames.",
+    "doc": "Alias of 'metadata'. Scan a frames directory and report timestamps, counts, and missing frames.",
     "epilog": "",
     "groups": [
       {
@@ -5393,6 +5541,67 @@
     "args_schema": null,
     "example_args": null
   },
+  "transform scan-frames": {
+    "description": "Alias of 'metadata'. Scan a frames directory and report timestamps, counts, and missing frames.",
+    "doc": "Alias of 'metadata'. Scan a frames directory and report timestamps, counts, and missing frames.",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--frames-dir",
+          "--pattern",
+          "--datetime-format",
+          "--period-seconds",
+          "--output",
+          "--verbose",
+          "--quiet",
+          "--trace"
+        ]
+      }
+    ],
+    "options": {
+      "--help": "show this help message and exit",
+      "--frames-dir": {
+        "help": "Directory containing frames",
+        "path_arg": true,
+        "type": "path",
+        "required": true
+      },
+      "--pattern": "Regex filter for frame filenames",
+      "--datetime-format": "Datetime format used in filenames (e.g., %Y%m%d%H%M%S)",
+      "--period-seconds": {
+        "help": "Expected cadence to compute missing frames",
+        "type": "int"
+      },
+      "--output": {
+        "help": "Output path or '-' for stdout",
+        "path_arg": true,
+        "type": "path",
+        "default": "-"
+      },
+      "--verbose": {
+        "help": "Verbose logging for this command",
+        "type": "bool",
+        "default": false
+      },
+      "--quiet": {
+        "help": "Quiet logging for this command",
+        "type": "bool",
+        "default": false
+      },
+      "--trace": {
+        "help": "Shell-style trace of key steps and external commands",
+        "type": "bool",
+        "default": false
+      }
+    },
+    "positionals": [],
+    "domain": "transform",
+    "args_schema": null,
+    "example_args": null
+  },
   "transform enrich-metadata": {
     "description": "Enrich a frames metadata JSON with dataset_id, Vimeo URI, and updated_at; read from file or stdin.",
     "doc": "Enrich a frames metadata JSON with dataset_id, Vimeo URI, and updated_at; read from file or stdin.",
@@ -6080,6 +6289,9 @@
           "--max-workers",
           "--max-rounds",
           "--pack",
+          "--rubric",
+          "--verbose",
+          "--quiet",
           "--input",
           "--critic-structured",
           "--attach-images",
@@ -6111,6 +6323,17 @@
         "type": "int"
       },
       "--pack": "Output file for Narrative Pack (yaml or json); '-' for stdout",
+      "--rubric": "Path to critic rubric YAML (defaults to packaged critic rubric)",
+      "--verbose": {
+        "help": "Verbose logging (shows per-agent dialog)",
+        "type": "bool",
+        "default": false
+      },
+      "--quiet": {
+        "help": "Quiet logging (errors only)",
+        "type": "bool",
+        "default": false
+      },
       "--input": {
         "help": "Optional input file path or '-' for stdin (JSON/YAML autodetect; falls back to text)",
         "path_arg": true,

--- a/tests/processing/test_pad_missing.py
+++ b/tests/processing/test_pad_missing.py
@@ -178,6 +178,3 @@ def test_transform_scan_frames_alias(tmp_path: Path) -> None:
     assert exit_code == 0
     data = json.loads(output.read_text(encoding="utf-8"))
     assert data["frame_count_actual"] == 1
-
-
-pytest.importorskip("PIL")

--- a/tests/processing/test_pad_missing.py
+++ b/tests/processing/test_pad_missing.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import argparse
+import json
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image, ImageChops
+
+from zyra.processing.pad_missing import pad_missing_frames
+from zyra.transform import register_cli as register_transform_cli
+
+
+def _make_frame(path: Path, color: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    img = Image.new("RGB", (64, 64), color)
+    img.save(path)
+
+
+@pytest.fixture()
+def frames_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    frames_dir = tmp_path / "frames"
+    output_dir = tmp_path / "out"
+    frames_dir.mkdir()
+    _make_frame(frames_dir / "frame_202401010000.png", "#ff0000")
+    _make_frame(frames_dir / "frame_202401010010.png", "#ff0000")
+    meta = {
+        "frames_dir": str(frames_dir),
+        "datetime_format": "%Y%m%d%H%M",
+        "missing_timestamps": ["2024-01-01T00:05:00"],
+    }
+    meta_path = tmp_path / "frames_meta.json"
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+    return frames_dir, output_dir, meta_path
+
+
+def test_pad_missing_blank_mode(frames_fixture: tuple[Path, Path, Path]) -> None:
+    _, output_dir, meta_path = frames_fixture
+    created = pad_missing_frames(
+        str(meta_path),
+        output_dir=str(output_dir),
+        fill_mode="blank",
+    )
+    expected = output_dir / "frame_202401010005.png"
+    assert expected in created
+    with Image.open(expected) as img:
+        assert img.size == (64, 64)
+        assert img.mode == "RGB"
+        assert img.getpixel((0, 0)) == (0, 0, 0)
+
+
+def test_pad_missing_solid_color(frames_fixture: tuple[Path, Path, Path]) -> None:
+    _, output_dir, meta_path = frames_fixture
+    shade = "#123456"
+    created = pad_missing_frames(
+        str(meta_path),
+        output_dir=str(output_dir / "solid"),
+        fill_mode="solid",
+        basemap=shade,
+    )
+    expected = output_dir / "solid" / "frame_202401010005.png"
+    assert expected in created
+    with Image.open(expected) as img:
+        assert img.getpixel((5, 5)) == Image.new("RGB", (1, 1), shade).getpixel((0, 0))
+
+
+def test_pad_missing_nearest_with_indicator(
+    frames_fixture: tuple[Path, Path, Path],
+) -> None:
+    frames_dir, output_dir, meta_path = frames_fixture
+    # Add an intermediate frame at a different color to ensure donor selection is deterministic
+    _make_frame(frames_dir / "frame_202401010015.png", "#0000ff")
+    created = pad_missing_frames(
+        str(meta_path),
+        output_dir=str(output_dir / "nearest"),
+        fill_mode="nearest",
+        indicator="watermark:MISSING",
+    )
+    expected = output_dir / "nearest" / "frame_202401010005.png"
+    assert expected in created
+    with Image.open(expected) as img, Image.open(
+        frames_dir / "frame_202401010000.png"
+    ) as base:
+        diff = ImageChops.difference(img, base)
+        assert diff.getbbox() is not None
+
+
+def test_pad_missing_json_report(
+    frames_fixture: tuple[Path, Path, Path], tmp_path: Path
+) -> None:
+    _, output_dir, meta_path = frames_fixture
+    report_path = tmp_path / "report.json"
+    pad_missing_frames(
+        str(meta_path),
+        output_dir=str(output_dir / "report"),
+        fill_mode="blank",
+        json_report=str(report_path),
+    )
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    assert data["status"] == "completed"
+    assert data["created_count"] == 1
+    assert data["created_files"]
+
+
+def test_pad_missing_json_report_dry_run(
+    frames_fixture: tuple[Path, Path, Path], tmp_path: Path
+) -> None:
+    _, output_dir, meta_path = frames_fixture
+    report_path = tmp_path / "report-dry.json"
+    pad_missing_frames(
+        str(meta_path),
+        output_dir=str(output_dir / "dry"),
+        fill_mode="blank",
+        dry_run=True,
+        json_report=str(report_path),
+    )
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    assert data["status"] == "dry-run"
+    assert data["created_count"] == 0
+    assert data["planned_count"] == 1
+    assert data["planned_files"]
+
+
+def test_pad_missing_reads_metadata_from_stdin(
+    frames_fixture: tuple[Path, Path, Path], tmp_path: Path
+) -> None:
+    _, output_dir, meta_path = frames_fixture
+    report_path = tmp_path / "stdin-report.json"
+    out_dir = output_dir / "stdin"
+
+    class _MockStdin:
+        def __init__(self, data: bytes) -> None:
+            self.buffer = BytesIO(data)
+
+    mock_stdin = _MockStdin(meta_path.read_bytes())
+    with patch("sys.stdin", mock_stdin):
+        pad_missing_frames(
+            "-",
+            output_dir=str(out_dir),
+            fill_mode="blank",
+            json_report=str(report_path),
+            read_stdin=True,
+        )
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    assert data["metadata_path"] == "-"
+    assert data["created_count"] == 1
+
+
+def test_transform_scan_frames_alias(tmp_path: Path) -> None:
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    _make_frame(frames_dir / "frame_202401010000.png", "#00ff00")
+    output = tmp_path / "meta.json"
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="cmd", required=True)
+    register_transform_cli(subparsers)
+
+    args = parser.parse_args(
+        [
+            "scan-frames",
+            "--frames-dir",
+            str(frames_dir),
+            "--datetime-format",
+            "%Y%m%d%H%M",
+            "-o",
+            str(output),
+        ]
+    )
+    exit_code = args.func(args)
+    assert exit_code == 0
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["frame_count_actual"] == 1

--- a/tests/processing/test_pad_missing.py
+++ b/tests/processing/test_pad_missing.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from PIL import Image, ImageChops
+
+try:
+    from PIL import Image, ImageChops
+except ModuleNotFoundError:
+    pytest.skip("Pillow is required for pad-missing tests", allow_module_level=True)
 
 from zyra.processing.pad_missing import pad_missing_frames
 from zyra.transform import register_cli as register_transform_cli
@@ -174,3 +178,6 @@ def test_transform_scan_frames_alias(tmp_path: Path) -> None:
     assert exit_code == 0
     data = json.loads(output.read_text(encoding="utf-8"))
     assert data["frame_count_actual"] == 1
+
+
+pytest.importorskip("PIL")


### PR DESCRIPTION
This pull request adds a new `pad-missing` command to the `zyra.processing` CLI for generating placeholder frames for missing timestamps using various strategies, and introduces a `scan-frames` alias for the existing `metadata` command in the `zyra.transform` CLI. Documentation and capability metadata have been updated to reflect these new features and options.

### New CLI features

**`pad-missing` command (zyra.processing):**
* Adds a new `pad-missing` CLI command to generate placeholder frames for missing timestamps using metadata from `transform scan-frames`, supporting multiple fill modes (blank, solid, basemap, nearest), basemap/color overlays, indicators, overwrite/dry-run options, and JSON reporting. [[1]](diffhunk://#diff-e9bed9d11ec7cb14d43f6c4d97710d5ae1019e8853a2e855ec3bada17a16a212R8) [[2]](diffhunk://#diff-e9bed9d11ec7cb14d43f6c4d97710d5ae1019e8853a2e855ec3bada17a16a212R62-R75) [[3]](diffhunk://#diff-0cb809cdb5ca5562fa7a8755d2085728bfc1a27fb7d71284b0503eb49cad8985R338-R373) [[4]](diffhunk://#diff-0cb809cdb5ca5562fa7a8755d2085728bfc1a27fb7d71284b0503eb49cad8985R714-R782) [[5]](diffhunk://#diff-7469006e85f8ae4e5f08010b69c15ad313988fc02e615b35cd1bb66839d23584R17-R21) [[6]](diffhunk://#diff-0cb809cdb5ca5562fa7a8755d2085728bfc1a27fb7d71284b0503eb49cad8985R26) [[7]](diffhunk://#diff-0cb809cdb5ca5562fa7a8755d2085728bfc1a27fb7d71284b0503eb49cad8985R42) [[8]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdR1524-R1610)

**`scan-frames` alias (zyra.transform):**
* Introduces `scan-frames` as an alias for the `metadata` command, providing clearer naming for scanning frame directories and reporting missing frames. Updates CLI registration, documentation, and adds an informational log when using the original `metadata` command. [[1]](diffhunk://#diff-15b51cf7c9698ce9c5ed22ddd572cae8210294bcacf2b4a43a0893ba5ecb1f41L4-R4) [[2]](diffhunk://#diff-15b51cf7c9698ce9c5ed22ddd572cae8210294bcacf2b4a43a0893ba5ecb1f41L16-R16) [[3]](diffhunk://#diff-8e72139a5341685f6478a48998e4f1832ae5ed15516fc1ce93dd2cc2750a1972R107-R113) [[4]](diffhunk://#diff-8e72139a5341685f6478a48998e4f1832ae5ed15516fc1ce93dd2cc2750a1972L131-R191) [[5]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdR5544-R5604)

### Documentation and capability metadata

**README and API docs updates:**
* Updates `README.md` files and Sphinx API docs to document the new `pad-missing` command, its options, usage examples, and the `scan-frames` alias. [[1]](diffhunk://#diff-e9bed9d11ec7cb14d43f6c4d97710d5ae1019e8853a2e855ec3bada17a16a212R8) [[2]](diffhunk://#diff-e9bed9d11ec7cb14d43f6c4d97710d5ae1019e8853a2e855ec3bada17a16a212R62-R75) [[3]](diffhunk://#diff-15b51cf7c9698ce9c5ed22ddd572cae8210294bcacf2b4a43a0893ba5ecb1f41L4-R4) [[4]](diffhunk://#diff-15b51cf7c9698ce9c5ed22ddd572cae8210294bcacf2b4a43a0893ba5ecb1f41L16-R16) [[5]](diffhunk://#diff-7469006e85f8ae4e5f08010b69c15ad313988fc02e615b35cd1bb66839d23584R17-R21)

**Wizard capabilities metadata:**
* Adds metadata for both `process pad-missing` and `scan-frames` commands (under both `process` and `transform` domains) to `zyra_capabilities.json`, listing all options and descriptions for wizard integration and API introspection. [[1]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdR1524-R1610) [[2]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdR1909-R1969) [[3]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdR5544-R5604)

**Critic rubric and logging options:**
* Extends options for critic-related commands to support rubric file selection and logging verbosity/quietness. [[1]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdR6292-R6294) [[2]](diffhunk://#diff-912170cde9f43edf0a2017354471c1f1645b2d1dcec42772e15998683db524cdR6326-R6336)