### PR TITLE
Implement notebook session framework with tool registration

### DIFF
--- a/samples/drought_notebook_walkthrough.ipynb
+++ b/samples/drought_notebook_walkthrough.ipynb
@@ -1,0 +1,474 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Zyra Notebook: Drought Animation Walkthrough (draft)\n",
+    "\n",
+    "This walkthrough recreates the `samples/swarm/drought_animation.yaml` flow:\n",
+    "\n",
+    "- Sync the last year of weekly drought frames from NOAA FTP.\n",
+    "- Scan frames metadata to identify cadence/missing timestamps.\n",
+    "- Fill gaps with a basemap-backed placeholder set.\n",
+    "- Compose an MP4 animation and write it locally.\n",
+    "- Optional narration via `narrate swarm` with mock-safe provider selection.\n",
+    "- Export pipeline/CLI equivalents for reproducibility.\n",
+    "\n",
+    "Prereqs: Pillow for `process pad-missing`, FFmpeg on `PATH` for `visualize compose-video`, and access to the packaged basemap `pkg:zyra.assets/images/earth_vegetation.jpg` (avoids external downloads).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "provider",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LLM model: gemma3:12b\n",
+      "LLM provider: ollama\n"
+     ]
+    }
+   ],
+   "source": [
+    "# LLM provider (optional narration; mock-safe fallback)\n",
+    "import os\n",
+    "\n",
+    "# Prefer Ollama; set base/model here if not already exported in the env\n",
+    "os.environ.setdefault(\"ZYRA_LLM_PROVIDER\", \"ollama\")\n",
+    "os.environ.setdefault(\"OLLAMA_BASE_URL\", \"http://host.docker.internal:11434\")\n",
+    "os.environ.setdefault(\"LLM_MODEL\", \"gemma3:12b\")\n",
+    "\n",
+    "PROVIDER = os.environ.get(\"ZYRA_LLM_PROVIDER\", \"ollama\")\n",
+    "AVAILABLE = {\"ollama\", \"openai\", \"google\", \"mock\"}\n",
+    "if PROVIDER not in AVAILABLE:\n",
+    "    PROVIDER = \"ollama\"\n",
+    "\n",
+    "\n",
+    "def choose_provider() -> str:\n",
+    "    has_openai = bool(os.environ.get(\"OPENAI_API_KEY\"))\n",
+    "    has_google = bool(os.environ.get(\"GOOGLE_API_KEY\"))\n",
+    "    has_ollama = bool(os.environ.get(\"OLLAMA_BASE_URL\"))\n",
+    "    if PROVIDER == \"openai\" and has_openai:\n",
+    "        return \"openai\"\n",
+    "    if PROVIDER == \"google\" and has_google:\n",
+    "        return \"google\"\n",
+    "    if PROVIDER == \"ollama\" and has_ollama:\n",
+    "        return \"ollama\"\n",
+    "    return \"mock\"\n",
+    "\n",
+    "\n",
+    "LLM_PROVIDER = choose_provider()\n",
+    "LLM_MODEL = os.environ.get(\"LLM_MODEL\")\n",
+    "print(\"LLM model:\", LLM_MODEL)\n",
+    "print(\"LLM provider:\", LLM_PROVIDER)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "session",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Workspace root: /app/data\n",
+      "Drought run dir: /app/data/drought_notebook\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Notebook session + workspace\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from zyra.notebook import create_session\n",
+    "\n",
+    "# Default workspace: ZYRA_NOTEBOOK_DIR -> /kaggle/working -> cwd\n",
+    "os.environ[\"ZYRA_NOTEBOOK_DIR\"] = \"/app/data\"\n",
+    "sess = create_session()\n",
+    "WORKSPACE = sess.workspace()\n",
+    "DROUGHT_DIR = WORKSPACE / \"drought_notebook\"\n",
+    "DROUGHT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "print(\"Workspace root:\", WORKSPACE)\n",
+    "print(\"Drought run dir:\", DROUGHT_DIR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "paths",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Raw frames dir: /app/data/drought_notebook/frames_raw\n",
+      "Padded frames dir: /app/data/drought_notebook/frames_padded\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Paths and cadence defaults\n",
+    "FRAMES_RAW = DROUGHT_DIR / \"frames_raw\"\n",
+    "FRAMES_PADDED = DROUGHT_DIR / \"frames_padded\"\n",
+    "FRAMES_META = DROUGHT_DIR / \"frames_meta.json\"\n",
+    "VIDEO_OUT = DROUGHT_DIR / \"drought_animation.mp4\"\n",
+    "BASEMAP_REF = \"pkg:zyra.assets/images/earth_vegetation.jpg\"\n",
+    "\n",
+    "FTP_PATH = \"ftp://ftp.nnvl.noaa.gov/SOS/DroughtRisk_Weekly\"\n",
+    "PATTERN = r\"^DroughtRisk_Weekly_[0-9]{8}\\.png$\"  # single-escaped dot\n",
+    "CADENCE_SECONDS = 7 * 24 * 3600\n",
+    "\n",
+    "for folder in (FRAMES_RAW, FRAMES_PADDED):\n",
+    "    folder.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "print(\"Raw frames dir:\", FRAMES_RAW)\n",
+    "print(\"Padded frames dir:\", FRAMES_PADDED)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "acquire",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Remote frames past year: 51\n",
+      "Remote date span: 2024-12-05 to 2025-11-20\n",
+      "Newest remote samples: ['DroughtRisk_Weekly_20251106.png', 'DroughtRisk_Weekly_20251113.png', 'DroughtRisk_Weekly_20251120.png']\n",
+      "Synced frames from FTP -> /app/data/drought_notebook/frames_raw\n",
+      "Local frames downloaded: 51\n",
+      "Newest local files: ['DroughtRisk_Weekly_20251106.png', 'DroughtRisk_Weekly_20251113.png', 'DroughtRisk_Weekly_20251120.png']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Acquire drought frames (FTP sync for the past year)\n",
+    "import contextlib\n",
+    "import re\n",
+    "from datetime import datetime\n",
+    "\n",
+    "from zyra.connectors.backends import ftp as ftp_backend\n",
+    "from zyra.utils.date_manager import DateManager\n",
+    "\n",
+    "\n",
+    "def frame_count(path: Path) -> int:\n",
+    "    return sum(1 for f in path.iterdir() if f.is_file())\n",
+    "\n",
+    "\n",
+    "date_start, _ = DateManager().get_date_range_iso(\"P1Y\")\n",
+    "remote_filtered = (\n",
+    "    ftp_backend.list_files(\n",
+    "        FTP_PATH,\n",
+    "        pattern=PATTERN,\n",
+    "        since=date_start.isoformat(),\n",
+    "        date_format=\"%Y%m%d\",\n",
+    "    )\n",
+    "    or []\n",
+    ")\n",
+    "dates = []\n",
+    "for name in remote_filtered:\n",
+    "    m = re.search(r\"(\\d{8})\", name)\n",
+    "    if m:\n",
+    "        with contextlib.suppress(Exception):\n",
+    "            dates.append(datetime.strptime(m.group(1), \"%Y%m%d\"))\n",
+    "print(f\"Remote frames past year: {len(remote_filtered)}\")\n",
+    "if dates:\n",
+    "    print(\"Remote date span:\", min(dates).date(), \"to\", max(dates).date())\n",
+    "if remote_filtered:\n",
+    "    print(\"Newest remote samples:\", remote_filtered[-3:])\n",
+    "\n",
+    "try:\n",
+    "    sess.acquire.ftp(\n",
+    "        path=FTP_PATH,\n",
+    "        sync_dir=str(FRAMES_RAW),\n",
+    "        pattern=PATTERN,\n",
+    "        since_period=\"P1Y\",\n",
+    "        date_format=\"%Y%m%d\",\n",
+    "    )\n",
+    "    print(\"Synced frames from FTP ->\", FRAMES_RAW)\n",
+    "except Exception as exc:\n",
+    "    raise RuntimeError(f\"FTP sync failed: {exc}\") from exc\n",
+    "\n",
+    "ready = frame_count(FRAMES_RAW)\n",
+    "print(f\"Local frames downloaded: {ready}\")\n",
+    "if ready:\n",
+    "    sample_local = sorted(FRAMES_RAW.iterdir())[-3:]\n",
+    "    print(\"Newest local files:\", [p.name for p in sample_local])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gap-note",
+   "metadata": {},
+   "source": [
+    "## Create a gap in the frames\n",
+    "We'll delete a couple of frames to see how pad-missing backfills missing timestamps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "gap-delete",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted frames: ['DroughtRisk_Weekly_20250109.png', 'DroughtRisk_Weekly_20250522.png']\n",
+      "Remaining frame count: 49\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Remove two frames to simulate missing data\n",
+    "import random\n",
+    "\n",
+    "frames = sorted(p for p in FRAMES_RAW.iterdir() if p.is_file())\n",
+    "if len(frames) < 2:\n",
+    "    print(\"Not enough frames to delete; skipping gap simulation\")\n",
+    "else:\n",
+    "    to_delete = random.sample(frames, 2)\n",
+    "    for fp in to_delete:\n",
+    "        fp.unlink(missing_ok=True)\n",
+    "    print(\"Deleted frames:\", [fp.name for fp in sorted(to_delete)])\n",
+    "    print(\"Remaining frame count:\", sum(1 for f in FRAMES_RAW.iterdir() if f.is_file()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "scan",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Frames meta: /app/data/drought_notebook/frames_meta.json\n",
+      "Actual frames: 49 Missing: 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Scan frames metadata (cadence, missing timestamps)\n",
+    "import json\n",
+    "\n",
+    "meta_result = sess.transform.scan_frames(\n",
+    "    frames_dir=str(FRAMES_RAW),\n",
+    "    pattern=PATTERN,\n",
+    "    datetime_format=\"%Y%m%d\",\n",
+    "    period_seconds=CADENCE_SECONDS,\n",
+    "    output=str(FRAMES_META),\n",
+    ")\n",
+    "summary = json.loads(FRAMES_META.read_text()) if FRAMES_META.exists() else {}\n",
+    "print(\"Frames meta:\", FRAMES_META)\n",
+    "print(\n",
+    "    \"Actual frames:\",\n",
+    "    summary.get(\"frame_count_actual\"),\n",
+    "    \"Missing:\",\n",
+    "    summary.get(\"missing_count\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "pad",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Padded frames dir: /app/data/drought_notebook/frames_padded\n",
+      "Total frames after padding: 51\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Fill missing frames using basemap placeholders\n",
+    "import shutil\n",
+    "\n",
+    "# Start padded dir fresh and seed it with existing frames\n",
+    "if FRAMES_PADDED.exists():\n",
+    "    shutil.rmtree(FRAMES_PADDED)\n",
+    "FRAMES_PADDED.mkdir(parents=True, exist_ok=True)\n",
+    "for src in FRAMES_RAW.iterdir():\n",
+    "    if src.is_file():\n",
+    "        shutil.copy2(src, FRAMES_PADDED / src.name)\n",
+    "\n",
+    "pad_result = sess.process.pad_missing(\n",
+    "    frames_meta=str(FRAMES_META),\n",
+    "    output_dir=str(FRAMES_PADDED),\n",
+    "    fill_mode=\"basemap\",\n",
+    "    basemap=BASEMAP_REF,\n",
+    "    overwrite=True,\n",
+    ")\n",
+    "filled = sum(1 for f in FRAMES_PADDED.iterdir() if f.is_file())\n",
+    "print(\"Padded frames dir:\", FRAMES_PADDED)\n",
+    "print(\"Total frames after padding:\", filled)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "compose",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Video path: /app/data/drought_notebook/drought_animation.mp4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compose MP4 animation from padded frames (requires ffmpeg on PATH)\n",
+    "video_path = sess.visualize.compose_video(\n",
+    "    frames=str(FRAMES_PADDED),\n",
+    "    output=str(VIDEO_OUT),\n",
+    "    fps=4,\n",
+    "    basemap=BASEMAP_REF,\n",
+    ")\n",
+    "print(\"Video path:\", video_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "disseminate",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Local copy: /app/data/drought_notebook/drought_animation.mp4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Save final animation locally (mirrors disseminate/local stage)\n",
+    "final_path = sess.disseminate.local(\n",
+    "    input=str(VIDEO_OUT),\n",
+    "    path=str(VIDEO_OUT),\n",
+    ")\n",
+    "print(\"Local copy:\", final_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "narrate",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Narration: The NOAA drought animation includes padded frames for weeks January 9, 2025, and May 22, 2025.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Optional narration of the drought animation\n",
+    "narration_meta = summary if isinstance(summary, dict) else {}\n",
+    "missing_dates = [\n",
+    "    str(ts).split(\"T\")[0] for ts in narration_meta.get(\"missing_timestamps\") or []\n",
+    "]\n",
+    "missing_dates_str = \", \".join(missing_dates) if missing_dates else \"none\"\n",
+    "narration_input = {\n",
+    "    \"title\": \"Weekly drought risk animation\",\n",
+    "    \"description\": f\"Summarize the NOAA drought animation, note where frames were padded, and list the padded weeks: {missing_dates_str}.\",\n",
+    "    \"data\": {\n",
+    "        \"frame_count_expected\": narration_meta.get(\"frame_count_expected\"),\n",
+    "        \"frame_count_actual\": narration_meta.get(\"frame_count_actual\"),\n",
+    "        \"missing_count\": narration_meta.get(\"missing_count\"),\n",
+    "        \"missing_timestamps\": narration_meta.get(\"missing_timestamps\") or [],\n",
+    "        \"frame_count_after_padding\": filled,\n",
+    "        \"padded_weeks\": missing_dates,\n",
+    "    },\n",
+    "}\n",
+    "try:\n",
+    "    narration = sess.narrate.swarm(\n",
+    "        provider=LLM_PROVIDER,\n",
+    "        model=LLM_MODEL,\n",
+    "        base_url=os.environ.get(\"OLLAMA_BASE_URL\"),\n",
+    "        preset=\"scientific_lite\",\n",
+    "        input_data=narration_input,\n",
+    "    )\n",
+    "    print(\"Narration:\", narration)\n",
+    "except Exception as exc:\n",
+    "    print(\"Narrate/swarm not executed:\", exc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "export",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pipeline saved to /app/data/drought_notebook/drought_pipeline.json\n",
+      "CLI commands:\n",
+      "zyra acquire ftp --path ftp://ftp.nnvl.noaa.gov/SOS/DroughtRisk_Weekly --sync-dir /app/data/drought_notebook/frames_raw --pattern ^DroughtRisk_Weekly_[0-9]{8}\\.png$ --since-period P1Y --date-format %Y%m%d --workdir /app/data --output /app/data/acquire_ftp.tmp\n",
+      "zyra transform scan-frames --frames-dir /app/data/drought_notebook/frames_raw --pattern ^DroughtRisk_Weekly_[0-9]{8}\\.png$ --datetime-format %Y%m%d --period-seconds 604800 --output /app/data/drought_notebook/frames_meta.json --workdir /app/data\n",
+      "zyra process pad-missing --frames-meta /app/data/drought_notebook/frames_meta.json --output-dir /app/data/drought_notebook/frames_padded --fill-mode basemap --basemap pkg:zyra.assets/images/earth_vegetation.jpg --overwrite --workdir /app/data\n",
+      "zyra visualize compose-video --frames /app/data/drought_notebook/frames_padded --output /app/data/drought_notebook/drought_animation.mp4 --fps 4 --basemap pkg:zyra.assets/images/earth_vegetation.jpg --workdir /app/data\n",
+      "zyra disseminate local --input /app/data/drought_notebook/drought_animation.mp4 --path /app/data/drought_notebook/drought_animation.mp4 --workdir /app/data\n",
+      "zyra narrate swarm --provider ollama --model gemma3:12b --base-url http://host.docker.internal:11434 --preset scientific_lite --input-data {'title': 'Weekly drought risk animation', 'description': 'Summarize the NOAA drought animation, note where frames were padded, and list the padded weeks: 2025-01-09, 2025-05-22.', 'data': {'frame_count_expected': 51, 'frame_count_actual': 49, 'missing_count': 2, 'missing_timestamps': ['2025-01-09T00:00:00', '2025-05-22T00:00:00'], 'frame_count_after_padding': 51, 'padded_weeks': ['2025-01-09', '2025-05-22']}} --workdir /app/data --swarm-config None --agents None --audiences None --style None --pack None --rubric None --input None --max-workers None --max-rounds None --memory None --guardrails None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Export pipeline + CLI equivalents for reproducibility\n",
+    "pipeline = sess.to_pipeline()\n",
+    "cli_cmds = sess.to_cli()\n",
+    "\n",
+    "pipeline_path = DROUGHT_DIR / \"drought_pipeline.json\"\n",
+    "pipeline_path.write_text(json.dumps(pipeline, indent=2))\n",
+    "print(\"Pipeline saved to\", pipeline_path)\n",
+    "print(\"CLI commands:\")\n",
+    "for cmd in cli_cmds:\n",
+    "    print(cmd)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "zyra-9TtSrW0h-py3.10",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/zyra/notebook/README.md
+++ b/src/zyra/notebook/README.md
@@ -1,0 +1,50 @@
+# zyra.notebook (draft)
+
+Notebook-friendly bridge for running Zyra stages inline, registering custom tools, logging provenance, and exporting reproducible pipelines.
+
+## Quick start
+
+```python
+from zyra.notebook import create_session
+
+# Optional: set env ZYRA_NOTEBOOK_DIR for workspace; defaults to /kaggle/working if present, else cwd.
+sess = create_session()
+
+# Acquire remote data (e.g., HTTP)
+data = sess.acquire.http(url="https://example.com/file.bin")
+
+# Register a custom tool
+def smooth(ds):
+    ...
+sess.process.register("smooth", smooth, returns="object")
+ds = sess.process.smooth(input=data)
+
+# Export pipeline/CLI
+pipeline = sess.to_pipeline()
+cli_cmds = sess.to_cli()
+```
+
+## LLM provider selection (notebook UX target)
+
+- Start notebook with a provider selector cell (default `ollama`; also `openai`, `google/gemini`; fallback `mock` when creds missing).
+- Document required env vars: `OLLAMA_BASE_URL`, `OPENAI_API_KEY`, `GOOGLE_API_KEY` (or Vertex vars).
+- Swarm narration cell should summarize upcoming expected 2 m temperature from the HRRR subset; allow provider override via cell param.
+
+## HRRR workflow (target for walkthrough notebook)
+
+1. Acquire a small HRRR 2 m temperature subset via HTTP/NCSS (tight bbox/time to keep a few MB).
+2. Process (subset/convert as needed).
+3. Visualize or export.
+4. Inline `process.register` demo.
+5. Provenance export + `to_pipeline` / `to_cli`.
+6. Narrate/swarm cell describing expected temperature (provider selector, mock-safe).
+
+## Defaults and paths
+
+- Workspace: `ZYRA_NOTEBOOK_DIR` -> `/kaggle/working` (if exists) -> `cwd`.
+- Provenance: `ZYRA_NOTEBOOK_PROVENANCE` or `${workdir}/provenance.sqlite`.
+
+## Limitations (current scaffolding)
+
+- Wrappers call underlying CLI handlers directly with argparse-style namespaces; richer return handling and signature shaping to follow.
+- Inline tool export is supported via stored callable metadata; serialized export for CLI replay is pending.

--- a/src/zyra/notebook/__init__.py
+++ b/src/zyra/notebook/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Notebook bridge scaffolding.
+
+This module will expose manifest-backed stage namespaces and a session/registry
+for notebook-friendly execution. Current implementation is a placeholder to
+anchor package structure for subsequent phases.
+"""
+
+from __future__ import annotations
+
+from zyra.notebook.registry import Session, create_session
+
+# Align with package version to avoid import errors in stubs/tests.
+try:
+    from zyra import __version__  # type: ignore
+except Exception:  # pragma: no cover - defensive fallback
+    __version__ = "0.0.0"
+
+__all__ = ["__version__", "Session", "create_session"]

--- a/src/zyra/notebook/registry.py
+++ b/src/zyra/notebook/registry.py
@@ -1,0 +1,412 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Notebook runtime scaffolding for manifest-backed stage functions.
+
+This module provides:
+- A Session that loads the capabilities manifest and exposes stage namespaces.
+- Lightweight wrapper generation using manifest hints (impl/returns/output_arg/stdin_arg).
+- Registry support for inline tool registration (to be implemented in subsequent phases).
+
+Phase 3 scope: define the interfaces and basic manifest loading.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from zyra.swarm import open_provenance_store
+from zyra.wizard.manifest import build_manifest
+
+DEFAULT_WORKDIR_ENV = "ZYRA_NOTEBOOK_DIR"
+DEFAULT_WORKDIR_FALLBACKS = [
+    Path("/kaggle/working"),
+    Path.cwd(),
+]
+DEFAULT_PROVENANCE_ENV = "ZYRA_NOTEBOOK_PROVENANCE"
+DEFAULT_PROVENANCE_ENV = "ZYRA_NOTEBOOK_PROVENANCE"
+
+
+def _noop_tool(ns: Any) -> dict[str, Any]:
+    """Test helper: echo namespace as dict."""
+
+    try:
+        return vars(ns)
+    except Exception:
+        return {}
+
+
+def _safe_repr(obj: Any) -> Any:
+    """Best-effort to convert an object to a JSON-safe representation."""
+
+    try:
+        if isinstance(obj, dict):
+            return {k: _safe_repr(v) for k, v in obj.items()}
+        if hasattr(obj, "__dict__"):
+            return {k: _safe_repr(v) for k, v in obj.__dict__.items()}
+        if isinstance(obj, (list, tuple)):
+            return [_safe_repr(v) for v in obj]
+        return obj
+    except Exception:
+        try:
+            return repr(obj)
+        except Exception:
+            return "<unserializable>"
+
+
+@dataclass
+class ToolMetadata:
+    """Metadata describing a tool callable."""
+
+    name: str
+    impl: dict[str, str] | None
+    callable_obj: Any | None
+    returns: str | None
+    output_arg: str | None
+    stdin_arg: str | None
+    extras: list[str] | None
+    side_effects: list[str] | None
+
+
+class ToolWrapper:
+    """Callable wrapper exposing manifest metadata and logging provenance."""
+
+    def __init__(self, meta: ToolMetadata, workdir: Path, session: Session) -> None:
+        self.meta = meta
+        self.workdir = workdir
+        self._session = session
+
+    def __call__(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:  # pragma: no cover - thin wrapper until full execution wiring
+        func = self._resolve_callable()
+        ns, capture_path = self._build_namespace(kwargs)
+        # Track last namespace for result post-processing (e.g., output paths).
+        with contextlib.suppress(Exception):
+            self._session._last_ns = ns  # noqa: SLF001
+        result = func(ns)
+        final = self._finalize_result(result, capture_path)
+        self._log_provenance(ns, final)
+        return final
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return f"<ToolWrapper {self.meta.name} returns={self.meta.returns or 'object'}>"
+
+    def _resolve_callable(self) -> Any:
+        if self.meta.callable_obj is not None:
+            return self.meta.callable_obj
+        if not self.meta.impl:
+            raise NotImplementedError(
+                f"No implementation metadata for tool '{self.meta.name}'"
+            )
+        module_name = self.meta.impl.get("module")
+        func_name = self.meta.impl.get("callable")
+        if not module_name or not func_name:
+            raise NotImplementedError(
+                f"Incomplete implementation metadata for tool '{self.meta.name}'"
+            )
+        try:
+            import importlib
+
+            mod = importlib.import_module(module_name)
+            func = getattr(mod, func_name)
+            return func
+        except Exception as exc:  # pragma: no cover - defensive
+            raise RuntimeError(
+                f"Failed to import callable for tool '{self.meta.name}': {exc}"
+            ) from exc
+
+    def _build_namespace(self, user_kwargs: dict[str, Any]) -> tuple[Any, Path | None]:
+        norm = {k.replace("-", "_"): v for k, v in user_kwargs.items()}
+        norm.setdefault("workdir", str(self.workdir))
+        capture: Path | None = None
+        out_flag = self.meta.output_arg or ""
+        if out_flag.startswith("--") and self.meta.returns == "bytes":
+            key = out_flag.lstrip("-").replace("-", "_")
+            desired = norm.get(key)
+            if not desired or desired == "-":
+                capture = (
+                    self._session.workspace()
+                    / f"{self.meta.name.replace(' ', '_')}.tmp"
+                )
+                norm[key] = str(capture)
+        # Command-specific defaults
+        if self.meta.name.startswith("narrate swarm"):
+            norm.setdefault("list_presets", False)
+            norm.setdefault("preset", None)
+            norm.setdefault("swarm_config", None)
+            norm.setdefault("agents", None)
+            norm.setdefault("audiences", None)
+            norm.setdefault("style", None)
+            norm.setdefault("provider", None)
+            norm.setdefault("model", None)
+            norm.setdefault("base_url", None)
+            norm.setdefault("pack", None)
+            norm.setdefault("rubric", None)
+            norm.setdefault("input", None)
+            norm.setdefault("max_workers", None)
+            norm.setdefault("max_rounds", None)
+            norm.setdefault("memory", None)
+            norm.setdefault("critic_structured", False)
+            norm.setdefault("attach_images", False)
+            norm.setdefault("strict_grounding", False)
+            norm.setdefault("guardrails", None)
+            norm.setdefault("strict_guardrails", False)
+        try:
+            import argparse
+
+            return argparse.Namespace(**norm), capture
+        except Exception:  # pragma: no cover - fall back
+
+            class _NS:  # pragma: no cover - safety fallback
+                def __init__(self, data: dict[str, Any]) -> None:
+                    self.__dict__.update(data)
+
+            return _NS(norm), capture
+
+    def _finalize_result(self, result: Any, capture_path: Path | None) -> Any:
+        # If the tool writes to a known output flag, surface that path even when the callable returns an exit code.
+        if (
+            self.meta.returns == "path"
+            and self.meta.output_arg
+            and self.meta.output_arg.startswith("--")
+        ):
+            arg_name = self.meta.output_arg.lstrip("-").replace("-", "_")
+            with contextlib.suppress(Exception):
+                target = getattr(self._session._last_ns, arg_name)  # noqa: SLF001
+                if target:
+                    return str(target)
+        if self.meta.returns == "bytes" and capture_path and capture_path.exists():
+            try:
+                data = capture_path.read_bytes()
+                return data
+            except Exception:
+                return result
+        if self.meta.returns == "path" and capture_path:
+            return str(capture_path)
+        return result
+
+    def _log_provenance(self, ns: Any, result: Any) -> None:
+        store = self._session.provenance_store()
+        if not store or not hasattr(store, "handle_event"):
+            return
+        # Track invocation for export helpers even if store handling fails
+        with contextlib.suppress(Exception):
+            self._session._invocations.append(  # noqa: SLF001
+                {
+                    "tool": self.meta.name,
+                    "kwargs": _safe_repr(ns),
+                    "returns": self.meta.returns or "object",
+                }
+            )
+        payload: dict[str, Any] = {
+            "tool": self.meta.name,
+            "returns": self.meta.returns or "object",
+            "workdir": str(self.workdir),
+        }
+        try:
+            payload["args"] = _safe_repr(ns)
+        except Exception:
+            payload["args"] = "<unavailable>"
+        try:
+            length = None
+            if isinstance(result, (bytes, bytearray)):
+                length = len(result)
+            elif hasattr(result, "__len__"):
+                length = len(result)  # type: ignore[arg-type]
+            payload["result_meta"] = {"type": type(result).__name__, "len": length}
+        except Exception:
+            payload["result_meta"] = {"type": type(result).__name__}
+        try:
+            store.handle_event("notebook_tool_completed", payload)
+        except Exception:
+            return
+
+
+class StageNamespace:
+    """Container for stage-specific tools (e.g., acquire.http)."""
+
+    def __init__(
+        self,
+        domain: str,
+        tools: dict[str, ToolMetadata],
+        workdir: Path,
+        session: Session,
+    ) -> None:
+        self._domain = domain
+        self._tools = tools
+        self._workdir = workdir
+        self._session = session
+
+    def __dir__(self) -> list[str]:  # pragma: no cover - cosmetic
+        return sorted(self._tools.keys())
+
+    def __getattr__(self, item: str) -> Any:
+        if item not in self._tools:
+            raise AttributeError(item)
+        return ToolWrapper(self._tools[item], self._workdir, self._session)
+
+    def register(
+        self,
+        name: str,
+        func: Any,
+        *,
+        returns: str | None = "object",
+        extras: list[str] | None = None,
+        side_effects: list[str] | None = None,
+    ) -> None:
+        """Register an inline tool callable for this stage."""
+
+        safe_name = name.replace("-", "_")
+        meta = ToolMetadata(
+            name=f"{self._domain} {name}",
+            impl={
+                "module": getattr(func, "__module__", None) or "",
+                "callable": getattr(func, "__name__", safe_name),
+            },
+            callable_obj=func,
+            returns=returns,
+            output_arg=None,
+            stdin_arg=None,
+            extras=extras,
+            side_effects=side_effects,
+        )
+        self._tools[safe_name] = meta
+
+
+class Session:
+    """Notebook session: holds manifest and stage namespaces."""
+
+    def __init__(
+        self,
+        manifest: dict[str, Any] | None = None,
+        workdir: Path | None = None,
+        provenance_path: Path | str | None = None,
+    ) -> None:
+        self._manifest = manifest or build_manifest()
+        self._workdir = self._resolve_workdir(workdir)
+        self._provenance_path = self._resolve_provenance_path(provenance_path)
+        self._provenance_store = open_provenance_store(self._provenance_path)
+        self.acquire = self._build_namespace("acquire")
+        self.process = self._build_namespace("process")
+        self.transform = self._build_namespace("transform")
+        self.visualize = self._build_namespace("visualize")
+        self.render = self._build_namespace("render")
+        self.disseminate = self._build_namespace("disseminate")
+        self.decimate = self._build_namespace("decimate")
+        self.export = self._build_namespace("export")
+        self.narrate = self._build_namespace("narrate")
+        self.verify = self._build_namespace("verify")
+        self.run = self._build_namespace("run")
+        self.search = self._build_namespace("search")
+        self.simulate = self._build_namespace("simulate")
+        self.decide = self._build_namespace("decide")
+        self.optimize = self._build_namespace("optimize")
+        self._invocations: list[dict[str, Any]] = []
+
+    def _resolve_workdir(self, override: Path | None) -> Path:
+        if override:
+            return Path(override).expanduser()
+        env_path = Path(os.environ.get(DEFAULT_WORKDIR_ENV, "")).expanduser()  # type: ignore[arg-type]
+        if env_path:
+            return env_path
+        for cand in DEFAULT_WORKDIR_FALLBACKS:
+            try:
+                if cand.exists() or cand.parent.exists():
+                    return cand
+            except Exception:
+                continue
+        return Path.cwd()
+
+    def _resolve_provenance_path(self, override: Path | str | None) -> Path | None:
+        if override:
+            return Path(override).expanduser()
+        env_path = os.environ.get(DEFAULT_PROVENANCE_ENV)
+        if env_path:
+            return Path(env_path).expanduser()
+        # Default: provenance.sqlite under workdir
+        return self._workdir / "provenance.sqlite"
+
+    def _build_namespace(self, domain: str) -> StageNamespace:
+        tools: dict[str, ToolMetadata] = {}
+        for key, meta in (self._manifest or {}).items():
+            if not isinstance(key, str):
+                continue
+            if not key.startswith(f"{domain} "):
+                continue
+            tool_name = key.split(" ", 1)[1]
+            tools[tool_name.replace("-", "_")] = ToolMetadata(
+                name=key,
+                impl=meta.get("impl"),
+                callable_obj=None,
+                returns=meta.get("returns"),
+                output_arg=meta.get("output_arg"),
+                stdin_arg=meta.get("stdin_arg"),
+                extras=meta.get("extras"),
+                side_effects=meta.get("side_effects"),
+            )
+        return StageNamespace(domain, tools, self._workdir, self)
+
+    def workspace(self) -> Path:
+        """Return the active working directory for notebook outputs."""
+
+        return self._workdir
+
+    def provenance_store(self) -> Any:
+        """Return the provenance store (null/SQLite depending on config)."""
+
+        return self._provenance_store
+
+    def to_pipeline(self) -> list[dict[str, Any]]:
+        """Export recorded invocations to a pipeline-like structure."""
+
+        stages: list[dict[str, Any]] = []
+        for inv in self._invocations:
+            tool = inv.get("tool")
+            if not isinstance(tool, str) or " " not in tool:
+                continue
+            domain, cmd = tool.split(" ", 1)
+            stages.append(
+                {
+                    "stage": domain,
+                    "command": cmd,
+                    "args": inv.get("kwargs") or {},
+                }
+            )
+        return stages
+
+    def to_cli(self) -> list[str]:
+        """Export recorded invocations to CLI-equivalent command strings."""
+
+        cli_cmds: list[str] = []
+        for inv in self._invocations:
+            tool = inv.get("tool")
+            if not isinstance(tool, str):
+                continue
+            args = inv.get("kwargs") or {}
+            parts = ["zyra"] + tool.split(" ")
+            for k, v in args.items():
+                flag = f"--{k.replace('_', '-')}"
+                if isinstance(v, bool):
+                    if v:
+                        parts.append(flag)
+                else:
+                    parts.extend([flag, str(v)])
+            cli_cmds.append(" ".join(parts))
+        return cli_cmds
+
+
+def create_session(
+    manifest: dict[str, Any] | None = None,
+    *,
+    workdir: Path | None = None,
+    provenance_path: Path | str | None = None,
+) -> Session:
+    """Factory for notebook sessions."""
+
+    return Session(manifest=manifest, workdir=workdir, provenance_path=provenance_path)
+
+
+__all__ = ["Session", "create_session", "StageNamespace", "ToolMetadata"]

--- a/src/zyra/processing/__init__.py
+++ b/src/zyra/processing/__init__.py
@@ -63,6 +63,23 @@ import sys
 from typing import Any
 
 
+def notebook_pad_missing(ns: Any) -> list[str]:
+    """Notebook-friendly shim for pad-missing (Namespace-style args)."""
+
+    source = getattr(ns, "frames_meta", None) or "-"
+    return pad_missing_frames(
+        source,
+        output_dir=getattr(ns, "output_dir", None),
+        fill_mode=getattr(ns, "fill_mode", None),
+        basemap=getattr(ns, "basemap", None),
+        indicator=getattr(ns, "indicator", None),
+        overwrite=bool(getattr(ns, "overwrite", False)),
+        dry_run=bool(getattr(ns, "dry_run", False)),
+        json_report=getattr(ns, "json_report", None),
+        read_stdin=bool(getattr(ns, "read_frames_meta_stdin", False)),
+    )
+
+
 def register_cli(subparsers: Any) -> None:
     """Register processing subcommands under a provided subparsers object.
 
@@ -378,6 +395,9 @@ def register_cli(subparsers: Any) -> None:
             except Exception:
                 logging.debug("Created frame: %s", path)
         return 0
+
+    # Expose pad-missing handler at module scope for notebook/manifest imports
+    globals()["cmd_pad_missing"] = cmd_pad_missing
 
     # ---- api-json processor helpers ----
     from zyra.utils.json_tools import get_by_path as _get_by_path

--- a/src/zyra/wizard/manifest.py
+++ b/src/zyra/wizard/manifest.py
@@ -38,6 +38,196 @@ DOMAIN_ALIAS_MAP: dict[str, str] = {
     "optimize": "decide",
 }
 
+# Optional notebook-friendly hints for selected commands.
+# Keys are manifest command names (e.g., "acquire http").
+NOTEBOOK_HINTS: dict[str, dict[str, object]] = {
+    # acquire/import
+    "acquire http": {
+        "returns": "bytes",
+        "output_arg": "--output",
+        "side_effects": ["--output-dir"],
+    },
+    "acquire s3": {
+        "returns": "bytes",
+        "output_arg": "--output",
+        "side_effects": ["--output-dir"],
+    },
+    "acquire ftp": {
+        "returns": "bytes",
+        "output_arg": "--output",
+        "side_effects": ["--output-dir"],
+    },
+    "acquire api": {
+        "returns": "bytes",
+        "output_arg": "--output",
+    },
+    "acquire vimeo": {
+        "returns": "bytes",
+        "output_arg": "--output",
+    },
+    # import (alias of acquire)
+    "import http": {
+        "returns": "bytes",
+        "output_arg": "--output",
+        "side_effects": ["--output-dir"],
+    },
+    "import s3": {
+        "returns": "bytes",
+        "output_arg": "--output",
+        "side_effects": ["--output-dir"],
+    },
+    "import ftp": {
+        "returns": "bytes",
+        "output_arg": "--output",
+        "side_effects": ["--output-dir"],
+    },
+    "import api": {
+        "returns": "bytes",
+        "output_arg": "--output",
+    },
+    "import vimeo": {
+        "returns": "bytes",
+        "output_arg": "--output",
+    },
+    # process/transform
+    "process convert-format": {
+        "returns": "path",
+        "output_arg": "--output",
+        "stdin_arg": "file_or_url",
+    },
+    "process extract-variable": {
+        "returns": "bytes",
+        "stdin_arg": "file_or_url",
+    },
+    "process decode-grib2": {
+        "returns": "bytes",
+        "stdin_arg": "file_or_url",
+        "extras": ["grib"],
+    },
+    "process pad-missing": {
+        "returns": "path",
+        "side_effects": ["--output-dir", "--json-report"],
+        "extras": ["pillow"],
+        "impl": {"module": "zyra.processing", "callable": "notebook_pad_missing"},
+    },
+    "process metadata": {"returns": "bytes"},
+    "process scan-frames": {"returns": "bytes"},
+    "process update-dataset-json": {"returns": "path"},
+    "process api-json": {"returns": "path", "stdin_arg": "file_or_url"},
+    "process audio-transcode": {"returns": "path", "output_arg": "--output"},
+    "process audio-metadata": {"returns": "bytes"},
+    "process video-transcode": {"returns": "path", "output_arg": "--output"},
+    # transform aliases mirror process counterparts
+    "transform metadata": {"returns": "bytes"},
+    "transform scan-frames": {"returns": "bytes"},
+    "transform update-dataset-json": {"returns": "path"},
+    "transform enrich-metadata": {"returns": "path"},
+    "transform enrich-datasets": {"returns": "path"},
+    # visualize/render
+    "visualize heatmap": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "visualize contour": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "visualize vector": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "visualize animate": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "visualize compose-video": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "visualize interactive": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "visualize timeseries": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    # render aliases
+    "render heatmap": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "render contour": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "render vector": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "render animate": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "render compose-video": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "render interactive": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    "render timeseries": {
+        "returns": "path",
+        "output_arg": "--output",
+        "extras": ["visualization"],
+    },
+    # decimate/disseminate/export
+    "decimate local": {"returns": "path", "output_arg": "--path"},
+    "decimate s3": {"returns": "uri", "output_arg": "--url"},
+    "decimate ftp": {"returns": "uri", "output_arg": "--path"},
+    "decimate post": {"returns": "uri", "output_arg": "--url"},
+    "decimate vimeo": {"returns": "uri"},
+    "disseminate local": {"returns": "path", "output_arg": "--path"},
+    "disseminate s3": {"returns": "uri", "output_arg": "--url"},
+    "disseminate ftp": {"returns": "uri", "output_arg": "--path"},
+    "disseminate post": {"returns": "uri", "output_arg": "--url"},
+    "disseminate vimeo": {"returns": "uri"},
+    "export local": {"returns": "path", "output_arg": "--path"},
+    "export s3": {"returns": "uri", "output_arg": "--url"},
+    "export ftp": {"returns": "uri", "output_arg": "--path"},
+    "export post": {"returns": "uri", "output_arg": "--url"},
+    "export vimeo": {"returns": "uri"},
+    # narrate/swarm
+    "narrate describe": {"returns": "text", "extras": ["llm"]},
+    "narrate swarm": {
+        "returns": "text",
+        "extras": ["llm"],
+        "impl": {"module": "zyra.narrate", "callable": "notebook_swarm"},
+    },
+    # verify/simulate/decide
+    "verify evaluate": {"returns": "text"},
+    "simulate sample": {"returns": "path"},
+    "decide optimize": {"returns": "object"},
+    "optimize optimize": {"returns": "object"},
+    # run/search
+    "run": {"returns": "object", "stdin_arg": "config"},
+    "search api": {"returns": "bytes", "output_arg": "--output"},
+}
+
 
 def _safe_add_group(
     sub: argparse._SubParsersAction,
@@ -476,6 +666,8 @@ def _traverse(parser: argparse.ArgumentParser, *, prefix: str = "") -> dict[str,
         # Leaf command: collect options, description, doc, epilog, and groups
         name = prefix.strip()
         if name:  # skip root
+            defaults = getattr(parser, "_defaults", {}) or {}
+            func = defaults.get("func") if isinstance(defaults, dict) else None
             # Option groups: preserve group titles and option flags
             groups: list[dict[str, Any]] = []
             for grp in getattr(parser, "_action_groups", []):  # type: ignore[attr-defined]
@@ -542,7 +734,38 @@ def _traverse(parser: argparse.ArgumentParser, *, prefix: str = "") -> dict[str,
                 },
             }
 
-            manifest[name] = {
+            def _default_returns(dom: str) -> str:
+                return {
+                    "acquire": "bytes",
+                    "import": "bytes",
+                    "process": "path",
+                    "transform": "path",
+                    "visualize": "path",
+                    "render": "path",
+                    "disseminate": "path",
+                    "decimate": "path",
+                    "export": "path",
+                    "narrate": "text",
+                    "verify": "object",
+                    "decide": "object",
+                    "optimize": "object",
+                    "run": "object",
+                    "search": "bytes",
+                    "simulate": "path",
+                }.get(dom, "object")
+
+            hints = NOTEBOOK_HINTS.get(name, {})
+            impl = None
+            if func:
+                try:
+                    impl = {"module": func.__module__, "callable": func.__name__}
+                except Exception:
+                    impl = None
+            hint_impl = hints.get("impl")
+            if hint_impl is not None:
+                impl = hint_impl
+
+            entry: dict[str, Any] = {
                 "description": (parser.description or parser.prog or "").strip(),
                 "doc": (parser.description or "") or "",
                 "epilog": (getattr(parser, "epilog", None) or ""),
@@ -556,7 +779,14 @@ def _traverse(parser: argparse.ArgumentParser, *, prefix: str = "") -> dict[str,
                     else None
                 ),
                 "example_args": examples.get((domain, tool)),
+                "impl": impl,
+                "returns": hints.get("returns") or _default_returns(domain),
             }
+            for key in ("output_arg", "stdin_arg", "extras", "side_effects"):
+                val = hints.get(key)
+                if val is not None:
+                    entry[key] = val
+            manifest[name] = entry
         return manifest
 
     for spa in sub_actions:  # type: ignore[misc]

--- a/src/zyra/wizard/zyra_capabilities.json
+++ b/src/zyra/wizard/zyra_capabilities.json
@@ -115,7 +115,16 @@
     "example_args": {
       "url": "https://example.com/file.bin",
       "output": "/tmp/file.bin"
-    }
+    },
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_http"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "acquire s3": {
     "description": "Fetch objects from Amazon S3 via s3:// URL or bucket/key. Supports unsigned access, listing prefixes, and batch via --inputs/--manifest.",
@@ -224,7 +233,16 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_s3"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "acquire ftp": {
     "description": "Fetch files via FTP (single path or batch). Optionally list or sync directories to a local folder.",
@@ -340,7 +358,16 @@
         "user"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_ftp"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "acquire vimeo": {
     "description": "Placeholder for fetching Vimeo videos by id. Not implemented yet.",
@@ -392,7 +419,13 @@
     ],
     "domain": "acquire",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_vimeo"
+    },
+    "returns": "bytes",
+    "output_arg": "--output"
   },
   "acquire api": {
     "description": "Call a REST API endpoint with headers/params/body. Supports cursor/page pagination.",
@@ -663,7 +696,13 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_api"
+    },
+    "returns": "bytes",
+    "output_arg": "--output"
   },
   "import http": {
     "description": "Fetch a file via HTTP(S) to a local path. Optionally list/filter directory pages, or fetch multiple URLs with --inputs/--manifest.",
@@ -778,7 +817,16 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_http"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "import s3": {
     "description": "Fetch objects from Amazon S3 via s3:// URL or bucket/key. Supports unsigned access, listing prefixes, and batch via --inputs/--manifest.",
@@ -869,7 +917,16 @@
     "positionals": [],
     "domain": "import",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_s3"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "import ftp": {
     "description": "Fetch files via FTP (single path or batch). Optionally list or sync directories to a local folder.",
@@ -965,7 +1022,16 @@
     ],
     "domain": "import",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_ftp"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "import vimeo": {
     "description": "Placeholder for fetching Vimeo videos by id. Not implemented yet.",
@@ -1017,7 +1083,13 @@
     ],
     "domain": "import",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_vimeo"
+    },
+    "returns": "bytes",
+    "output_arg": "--output"
   },
   "import api": {
     "description": "Call a REST API endpoint with headers/params/body. Supports cursor/page pagination.",
@@ -1288,7 +1360,13 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_api"
+    },
+    "returns": "bytes",
+    "output_arg": "--output"
   },
   "process decode-grib2": {
     "description": "Decode a GRIB2 file or URL using cfgrib/pygrib/wgrib2 and log basic metadata. Optionally emit raw bytes (with optional .idx subset) to stdout.",
@@ -1368,7 +1446,16 @@
         "unsigned"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "cmd_decode_grib2"
+    },
+    "returns": "bytes",
+    "stdin_arg": "file_or_url",
+    "extras": [
+      "grib"
+    ]
   },
   "process extract-variable": {
     "description": "Extract a variable from GRIB2 by regex pattern. Output selected variable as NetCDF/GRIB2 to stdout when requested, or log the matched variable name.",
@@ -1456,7 +1543,13 @@
         "stdout"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "cmd_extract_variable"
+    },
+    "returns": "bytes",
+    "stdin_arg": "file_or_url"
   },
   "process convert-format": {
     "description": "Convert decoded GRIB2 data to NetCDF or GeoTIFF. Supports single input or batch via --inputs.",
@@ -1576,7 +1669,14 @@
       "file_or_url": "samples/demo.grib2",
       "format": "netcdf",
       "stdout": true
-    }
+    },
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "cmd_convert_format"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "stdin_arg": "file_or_url"
   },
   "process pad-missing": {
     "description": "Read frames metadata JSON from 'transform metadata/scan-frames' and generate placeholder images for each missing timestamp using blank, solid color, basemap, or nearest-frame strategies.",
@@ -1663,7 +1763,19 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "notebook_pad_missing"
+    },
+    "returns": "path",
+    "extras": [
+      "pillow"
+    ],
+    "side_effects": [
+      "--output-dir",
+      "--json-report"
+    ]
   },
   "process api-json": {
     "description": "Read a JSON or NDJSON file/stream, select fields via dot paths, optionally flatten nested objects, explode arrays into multiple rows, and write CSV or JSONL.",
@@ -1749,7 +1861,13 @@
         "records_path"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "cmd_api_json"
+    },
+    "returns": "path",
+    "stdin_arg": "file_or_url"
   },
   "process video-transcode": {
     "description": "Transcode videos or JPG image stacks into modern or legacy formats using FFmpeg. Supports SOS presets, metadata capture, and batch processing.",
@@ -1902,7 +2020,13 @@
         "write_metadata"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "_vt_entry"
+    },
+    "returns": "path",
+    "output_arg": "--output"
   },
   "process audio-transcode": {
     "description": "Transcode input audio to a target format using ffmpeg. Requires FFmpeg runtime.",
@@ -1994,7 +2118,13 @@
         "to"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "_at_entry"
+    },
+    "returns": "path",
+    "output_arg": "--output"
   },
   "process audio-metadata": {
     "description": "Run ffprobe to extract duration, bitrate, channels, sample rate, codec, and size; writes JSON.",
@@ -2053,7 +2183,12 @@
         "output"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "cmd_audio_metadata"
+    },
+    "returns": "bytes"
   },
   "process metadata": {
     "description": "Scan a frames directory to compute start/end timestamps, counts, and missing frames on a cadence.",
@@ -2114,7 +2249,12 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_metadata"
+    },
+    "returns": "bytes"
   },
   "process scan-frames": {
     "description": "Alias of 'metadata'. Scan a frames directory and report timestamps, counts, and missing frames.",
@@ -2175,7 +2315,12 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_metadata"
+    },
+    "returns": "bytes"
   },
   "process enrich-metadata": {
     "description": "Enrich a frames metadata JSON with dataset_id, Vimeo URI, and updated_at; read from file or stdin.",
@@ -2242,7 +2387,12 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_enrich"
+    },
+    "returns": "path"
   },
   "process enrich-datasets": {
     "description": "zyra process enrich-datasets",
@@ -2347,7 +2497,12 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_enrich_datasets"
+    },
+    "returns": "path"
   },
   "process update-dataset-json": {
     "description": "Update a dataset.json entry by id using metadata (start/end and Vimeo URI) from a file, stdin, or args.",
@@ -2430,7 +2585,12 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_update_dataset"
+    },
+    "returns": "path"
   },
   "visualize heatmap": {
     "description": "zyra visualize heatmap",
@@ -2632,7 +2792,16 @@
     "example_args": {
       "input": "samples/demo.npy",
       "output": "/tmp/heatmap.png"
-    }
+    },
+    "impl": {
+      "module": "zyra.visualization.cli_heatmap",
+      "callable": "handle_heatmap"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize contour": {
     "description": "zyra visualize contour",
@@ -2829,7 +2998,16 @@
         "output_dir"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_contour",
+      "callable": "handle_contour"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize timeseries": {
     "description": "zyra visualize timeseries",
@@ -2938,7 +3116,16 @@
         "ylabel"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_timeseries",
+      "callable": "handle_timeseries"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize vector": {
     "description": "zyra visualize vector",
@@ -3135,7 +3322,16 @@
         "xarray_engine"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_vector",
+      "callable": "handle_vector"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize animate": {
     "description": "zyra visualize animate",
@@ -3425,7 +3621,16 @@
         "width"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_animate",
+      "callable": "handle_animate"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize compose-video": {
     "description": "zyra visualize compose-video",
@@ -3496,7 +3701,16 @@
         "fps"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_compose_video",
+      "callable": "handle_compose_video"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize interactive": {
     "description": "zyra visualize interactive",
@@ -3708,7 +3922,16 @@
         "zoom"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_interactive",
+      "callable": "handle_interactive"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render heatmap": {
     "description": "zyra render heatmap",
@@ -3882,7 +4105,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_heatmap",
+      "callable": "handle_heatmap"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render contour": {
     "description": "zyra render contour",
@@ -4068,7 +4300,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_contour",
+      "callable": "handle_contour"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render timeseries": {
     "description": "zyra render timeseries",
@@ -4160,7 +4401,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_timeseries",
+      "callable": "handle_timeseries"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render vector": {
     "description": "zyra render vector",
@@ -4330,7 +4580,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_vector",
+      "callable": "handle_vector"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render animate": {
     "description": "zyra render animate",
@@ -4596,7 +4855,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_animate",
+      "callable": "handle_animate"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render compose-video": {
     "description": "zyra render compose-video",
@@ -4658,7 +4926,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_compose_video",
+      "callable": "handle_compose_video"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render interactive": {
     "description": "zyra render interactive",
@@ -4826,7 +5103,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_interactive",
+      "callable": "handle_interactive"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "disseminate local": {
     "description": "Write stdin or an input file to a local destination path, creating parent directories as needed.",
@@ -4884,7 +5170,13 @@
       ],
       "optional": []
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_local"
+    },
+    "returns": "path",
+    "output_arg": "--path"
   },
   "disseminate s3": {
     "description": "Upload stdin or an input file to Amazon S3, specified by s3:// URL or bucket/key.",
@@ -4949,7 +5241,13 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_s3"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "disseminate ftp": {
     "description": "Upload stdin or an input file to an FTP destination path.",
@@ -5021,7 +5319,13 @@
         "user"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_ftp"
+    },
+    "returns": "uri",
+    "output_arg": "--path"
   },
   "disseminate post": {
     "description": "HTTP POST stdin or an input file to a URL with optional content-type.",
@@ -5097,7 +5401,13 @@
         "headers"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_post"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "disseminate vimeo": {
     "description": "Upload a new video to Vimeo or replace an existing video by URI. Optionally set title and description.",
@@ -5160,7 +5470,12 @@
     "positionals": [],
     "domain": "disseminate",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_vimeo"
+    },
+    "returns": "uri"
   },
   "export local": {
     "description": "Write stdin or an input file to a local destination path, creating parent directories as needed.",
@@ -5212,7 +5527,13 @@
     ],
     "domain": "export",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_local"
+    },
+    "returns": "path",
+    "output_arg": "--path"
   },
   "export s3": {
     "description": "Upload stdin or an input file to Amazon S3, specified by s3:// URL or bucket/key.",
@@ -5268,7 +5589,13 @@
     "positionals": [],
     "domain": "export",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_s3"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "export ftp": {
     "description": "Upload stdin or an input file to an FTP destination path.",
@@ -5328,7 +5655,13 @@
     ],
     "domain": "export",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_ftp"
+    },
+    "returns": "uri",
+    "output_arg": "--path"
   },
   "export post": {
     "description": "HTTP POST stdin or an input file to a URL with optional content-type.",
@@ -5390,7 +5723,13 @@
     ],
     "domain": "export",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_post"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "export vimeo": {
     "description": "Upload a new video to Vimeo or replace an existing video by URI. Optionally set title and description.",
@@ -5453,7 +5792,12 @@
     "positionals": [],
     "domain": "export",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_vimeo"
+    },
+    "returns": "uri"
   },
   "decimate local": {
     "description": "Write stdin or an input file to a local destination path, creating parent directories as needed.",
@@ -5514,7 +5858,13 @@
     "example_args": {
       "input": "-",
       "path": "/tmp/out.bin"
-    }
+    },
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_local"
+    },
+    "returns": "path",
+    "output_arg": "--path"
   },
   "decimate s3": {
     "description": "Upload stdin or an input file to Amazon S3, specified by s3:// URL or bucket/key.",
@@ -5579,7 +5929,13 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_s3"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "decimate ftp": {
     "description": "Upload stdin or an input file to an FTP destination path.",
@@ -5651,7 +6007,13 @@
         "user"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_ftp"
+    },
+    "returns": "uri",
+    "output_arg": "--path"
   },
   "decimate post": {
     "description": "HTTP POST stdin or an input file to a URL with optional content-type.",
@@ -5727,7 +6089,13 @@
         "headers"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_post"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "decimate vimeo": {
     "description": "Upload a new video to Vimeo or replace an existing video by URI. Optionally set title and description.",
@@ -5790,7 +6158,12 @@
     "positionals": [],
     "domain": "decimate",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_vimeo"
+    },
+    "returns": "uri"
   },
   "transform metadata": {
     "description": "Scan a frames directory to compute start/end timestamps, counts, and missing frames on a cadence.",
@@ -5851,7 +6224,12 @@
     "positionals": [],
     "domain": "transform",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_metadata"
+    },
+    "returns": "bytes"
   },
   "transform scan-frames": {
     "description": "Alias of 'metadata'. Scan a frames directory and report timestamps, counts, and missing frames.",
@@ -5912,7 +6290,12 @@
     "positionals": [],
     "domain": "transform",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_metadata"
+    },
+    "returns": "bytes"
   },
   "transform enrich-metadata": {
     "description": "Enrich a frames metadata JSON with dataset_id, Vimeo URI, and updated_at; read from file or stdin.",
@@ -5979,7 +6362,12 @@
     "positionals": [],
     "domain": "transform",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_enrich"
+    },
+    "returns": "path"
   },
   "transform enrich-datasets": {
     "description": "zyra transform enrich-datasets",
@@ -6084,7 +6472,12 @@
     "positionals": [],
     "domain": "transform",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_enrich_datasets"
+    },
+    "returns": "path"
   },
   "transform update-dataset-json": {
     "description": "Update a dataset.json entry by id using metadata (start/end and Vimeo URI) from a file, stdin, or args.",
@@ -6167,7 +6560,12 @@
     "positionals": [],
     "domain": "transform",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_update_dataset"
+    },
+    "returns": "path"
   },
   "search api": {
     "description": "zyra search api",
@@ -6313,7 +6711,13 @@
     "positionals": [],
     "domain": "search",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.discovery",
+      "callable": "_cmd_api"
+    },
+    "returns": "bytes",
+    "output_arg": "--output"
   },
   "run": {
     "description": "zyra run",
@@ -6459,7 +6863,13 @@
     ],
     "domain": "run",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.pipeline_runner",
+      "callable": "_cmd"
+    },
+    "returns": "object",
+    "stdin_arg": "config"
   },
   "simulate sample": {
     "description": "zyra simulate sample",
@@ -6496,7 +6906,12 @@
         "trials"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.simulate",
+      "callable": "_cmd_sample"
+    },
+    "returns": "path"
   },
   "decide optimize": {
     "description": "zyra decide optimize",
@@ -6531,7 +6946,12 @@
         "strategy"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.decide",
+      "callable": "_cmd_optimize"
+    },
+    "returns": "object"
   },
   "optimize optimize": {
     "description": "zyra optimize optimize",
@@ -6561,7 +6981,12 @@
     "positionals": [],
     "domain": "optimize",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.decide",
+      "callable": "_cmd_optimize"
+    },
+    "returns": "object"
   },
   "narrate describe": {
     "description": "zyra narrate describe",
@@ -6588,7 +7013,15 @@
         "topic"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.narrate",
+      "callable": "_cmd_describe"
+    },
+    "returns": "text",
+    "extras": [
+      "llm"
+    ]
   },
   "narrate swarm": {
     "description": "Run a lightweight narration swarm with presets and YAML merging. When audiences are provided, an internal audience_adapter agent emits <aud>_version outputs. Provenance is recorded per agent with started/model/prompt_ref/duration_ms and included in the Narrative Pack.",
@@ -6708,7 +7141,15 @@
         "swarm_config"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.narrate",
+      "callable": "notebook_swarm"
+    },
+    "returns": "text",
+    "extras": [
+      "llm"
+    ]
   },
   "verify evaluate": {
     "description": "zyra verify evaluate",
@@ -6745,6 +7186,11 @@
         "metric"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.verify",
+      "callable": "_cmd_evaluate"
+    },
+    "returns": "text"
   }
 }

--- a/src/zyra/wizard/zyra_capabilities/acquire.json
+++ b/src/zyra/wizard/zyra_capabilities/acquire.json
@@ -268,7 +268,13 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_api"
+    },
+    "returns": "bytes",
+    "output_arg": "--output"
   },
   "acquire ftp": {
     "description": "Fetch files via FTP (single path or batch). Optionally list or sync directories to a local folder.",
@@ -384,7 +390,16 @@
         "user"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_ftp"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "acquire http": {
     "description": "Fetch a file via HTTP(S) to a local path. Optionally list/filter directory pages, or fetch multiple URLs with --inputs/--manifest.",
@@ -502,7 +517,16 @@
     "example_args": {
       "url": "https://example.com/file.bin",
       "output": "/tmp/file.bin"
-    }
+    },
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_http"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "acquire s3": {
     "description": "Fetch objects from Amazon S3 via s3:// URL or bucket/key. Supports unsigned access, listing prefixes, and batch via --inputs/--manifest.",
@@ -611,7 +635,16 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_s3"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "acquire vimeo": {
     "description": "Placeholder for fetching Vimeo videos by id. Not implemented yet.",
@@ -663,7 +696,13 @@
     ],
     "domain": "acquire",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_vimeo"
+    },
+    "returns": "bytes",
+    "output_arg": "--output"
   },
   "import api": {
     "description": "Call a REST API endpoint with headers/params/body. Supports cursor/page pagination.",
@@ -934,7 +973,13 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_api"
+    },
+    "returns": "bytes",
+    "output_arg": "--output"
   },
   "import ftp": {
     "description": "Fetch files via FTP (single path or batch). Optionally list or sync directories to a local folder.",
@@ -1030,7 +1075,16 @@
     ],
     "domain": "import",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_ftp"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "import http": {
     "description": "Fetch a file via HTTP(S) to a local path. Optionally list/filter directory pages, or fetch multiple URLs with --inputs/--manifest.",
@@ -1145,7 +1199,16 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_http"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "import s3": {
     "description": "Fetch objects from Amazon S3 via s3:// URL or bucket/key. Supports unsigned access, listing prefixes, and batch via --inputs/--manifest.",
@@ -1236,7 +1299,16 @@
     "positionals": [],
     "domain": "import",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_s3"
+    },
+    "returns": "bytes",
+    "output_arg": "--output",
+    "side_effects": [
+      "--output-dir"
+    ]
   },
   "import vimeo": {
     "description": "Placeholder for fetching Vimeo videos by id. Not implemented yet.",
@@ -1288,6 +1360,12 @@
     ],
     "domain": "import",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.ingest",
+      "callable": "_cmd_vimeo"
+    },
+    "returns": "bytes",
+    "output_arg": "--output"
   }
 }

--- a/src/zyra/wizard/zyra_capabilities/decide.json
+++ b/src/zyra/wizard/zyra_capabilities/decide.json
@@ -32,7 +32,12 @@
         "strategy"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.decide",
+      "callable": "_cmd_optimize"
+    },
+    "returns": "object"
   },
   "optimize optimize": {
     "description": "zyra optimize optimize",
@@ -62,6 +67,11 @@
     "positionals": [],
     "domain": "optimize",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.decide",
+      "callable": "_cmd_optimize"
+    },
+    "returns": "object"
   }
 }

--- a/src/zyra/wizard/zyra_capabilities/disseminate.json
+++ b/src/zyra/wizard/zyra_capabilities/disseminate.json
@@ -69,7 +69,13 @@
         "user"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_ftp"
+    },
+    "returns": "uri",
+    "output_arg": "--path"
   },
   "decimate local": {
     "description": "Write stdin or an input file to a local destination path, creating parent directories as needed.",
@@ -130,7 +136,13 @@
     "example_args": {
       "input": "-",
       "path": "/tmp/out.bin"
-    }
+    },
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_local"
+    },
+    "returns": "path",
+    "output_arg": "--path"
   },
   "decimate post": {
     "description": "HTTP POST stdin or an input file to a URL with optional content-type.",
@@ -206,7 +218,13 @@
         "headers"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_post"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "decimate s3": {
     "description": "Upload stdin or an input file to Amazon S3, specified by s3:// URL or bucket/key.",
@@ -271,7 +289,13 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_s3"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "decimate vimeo": {
     "description": "Upload a new video to Vimeo or replace an existing video by URI. Optionally set title and description.",
@@ -334,7 +358,12 @@
     "positionals": [],
     "domain": "decimate",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_vimeo"
+    },
+    "returns": "uri"
   },
   "disseminate ftp": {
     "description": "Upload stdin or an input file to an FTP destination path.",
@@ -406,7 +435,13 @@
         "user"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_ftp"
+    },
+    "returns": "uri",
+    "output_arg": "--path"
   },
   "disseminate local": {
     "description": "Write stdin or an input file to a local destination path, creating parent directories as needed.",
@@ -464,7 +499,13 @@
       ],
       "optional": []
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_local"
+    },
+    "returns": "path",
+    "output_arg": "--path"
   },
   "disseminate post": {
     "description": "HTTP POST stdin or an input file to a URL with optional content-type.",
@@ -540,7 +581,13 @@
         "headers"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_post"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "disseminate s3": {
     "description": "Upload stdin or an input file to Amazon S3, specified by s3:// URL or bucket/key.",
@@ -605,7 +652,13 @@
         "url"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_s3"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "disseminate vimeo": {
     "description": "Upload a new video to Vimeo or replace an existing video by URI. Optionally set title and description.",
@@ -668,7 +721,12 @@
     "positionals": [],
     "domain": "disseminate",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_vimeo"
+    },
+    "returns": "uri"
   },
   "export ftp": {
     "description": "Upload stdin or an input file to an FTP destination path.",
@@ -728,7 +786,13 @@
     ],
     "domain": "export",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_ftp"
+    },
+    "returns": "uri",
+    "output_arg": "--path"
   },
   "export local": {
     "description": "Write stdin or an input file to a local destination path, creating parent directories as needed.",
@@ -780,7 +844,13 @@
     ],
     "domain": "export",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_local"
+    },
+    "returns": "path",
+    "output_arg": "--path"
   },
   "export post": {
     "description": "HTTP POST stdin or an input file to a URL with optional content-type.",
@@ -842,7 +912,13 @@
     ],
     "domain": "export",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_post"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "export s3": {
     "description": "Upload stdin or an input file to Amazon S3, specified by s3:// URL or bucket/key.",
@@ -898,7 +974,13 @@
     "positionals": [],
     "domain": "export",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_s3"
+    },
+    "returns": "uri",
+    "output_arg": "--url"
   },
   "export vimeo": {
     "description": "Upload a new video to Vimeo or replace an existing video by URI. Optionally set title and description.",
@@ -961,6 +1043,11 @@
     "positionals": [],
     "domain": "export",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.egress",
+      "callable": "_cmd_vimeo"
+    },
+    "returns": "uri"
   }
 }

--- a/src/zyra/wizard/zyra_capabilities/narrate.json
+++ b/src/zyra/wizard/zyra_capabilities/narrate.json
@@ -24,7 +24,15 @@
         "topic"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.narrate",
+      "callable": "_cmd_describe"
+    },
+    "returns": "text",
+    "extras": [
+      "llm"
+    ]
   },
   "narrate swarm": {
     "description": "Run a lightweight narration swarm with presets and YAML merging. When audiences are provided, an internal audience_adapter agent emits <aud>_version outputs. Provenance is recorded per agent with started/model/prompt_ref/duration_ms and included in the Narrative Pack.",
@@ -144,6 +152,14 @@
         "swarm_config"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.narrate",
+      "callable": "notebook_swarm"
+    },
+    "returns": "text",
+    "extras": [
+      "llm"
+    ]
   }
 }

--- a/src/zyra/wizard/zyra_capabilities/process.json
+++ b/src/zyra/wizard/zyra_capabilities/process.json
@@ -83,7 +83,13 @@
         "records_path"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "cmd_api_json"
+    },
+    "returns": "path",
+    "stdin_arg": "file_or_url"
   },
   "process audio-metadata": {
     "description": "Run ffprobe to extract duration, bitrate, channels, sample rate, codec, and size; writes JSON.",
@@ -142,7 +148,12 @@
         "output"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "cmd_audio_metadata"
+    },
+    "returns": "bytes"
   },
   "process audio-transcode": {
     "description": "Transcode input audio to a target format using ffmpeg. Requires FFmpeg runtime.",
@@ -234,7 +245,13 @@
         "to"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "_at_entry"
+    },
+    "returns": "path",
+    "output_arg": "--output"
   },
   "process convert-format": {
     "description": "Convert decoded GRIB2 data to NetCDF or GeoTIFF. Supports single input or batch via --inputs.",
@@ -354,7 +371,14 @@
       "file_or_url": "samples/demo.grib2",
       "format": "netcdf",
       "stdout": true
-    }
+    },
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "cmd_convert_format"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "stdin_arg": "file_or_url"
   },
   "process decode-grib2": {
     "description": "Decode a GRIB2 file or URL using cfgrib/pygrib/wgrib2 and log basic metadata. Optionally emit raw bytes (with optional .idx subset) to stdout.",
@@ -434,7 +458,16 @@
         "unsigned"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "cmd_decode_grib2"
+    },
+    "returns": "bytes",
+    "stdin_arg": "file_or_url",
+    "extras": [
+      "grib"
+    ]
   },
   "process enrich-datasets": {
     "description": "zyra process enrich-datasets",
@@ -539,7 +572,12 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_enrich_datasets"
+    },
+    "returns": "path"
   },
   "process enrich-metadata": {
     "description": "Enrich a frames metadata JSON with dataset_id, Vimeo URI, and updated_at; read from file or stdin.",
@@ -606,7 +644,12 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_enrich"
+    },
+    "returns": "path"
   },
   "process extract-variable": {
     "description": "Extract a variable from GRIB2 by regex pattern. Output selected variable as NetCDF/GRIB2 to stdout when requested, or log the matched variable name.",
@@ -694,7 +737,13 @@
         "stdout"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "cmd_extract_variable"
+    },
+    "returns": "bytes",
+    "stdin_arg": "file_or_url"
   },
   "process metadata": {
     "description": "Scan a frames directory to compute start/end timestamps, counts, and missing frames on a cadence.",
@@ -755,7 +804,12 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_metadata"
+    },
+    "returns": "bytes"
   },
   "process pad-missing": {
     "description": "Read frames metadata JSON from 'transform metadata/scan-frames' and generate placeholder images for each missing timestamp using blank, solid color, basemap, or nearest-frame strategies.",
@@ -842,7 +896,19 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "notebook_pad_missing"
+    },
+    "returns": "path",
+    "extras": [
+      "pillow"
+    ],
+    "side_effects": [
+      "--output-dir",
+      "--json-report"
+    ]
   },
   "process scan-frames": {
     "description": "Alias of 'metadata'. Scan a frames directory and report timestamps, counts, and missing frames.",
@@ -903,7 +969,12 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_metadata"
+    },
+    "returns": "bytes"
   },
   "process update-dataset-json": {
     "description": "Update a dataset.json entry by id using metadata (start/end and Vimeo URI) from a file, stdin, or args.",
@@ -986,7 +1057,12 @@
     "positionals": [],
     "domain": "process",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_update_dataset"
+    },
+    "returns": "path"
   },
   "process video-transcode": {
     "description": "Transcode videos or JPG image stacks into modern or legacy formats using FFmpeg. Supports SOS presets, metadata capture, and batch processing.",
@@ -1139,6 +1215,12 @@
         "write_metadata"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.processing",
+      "callable": "_vt_entry"
+    },
+    "returns": "path",
+    "output_arg": "--output"
   }
 }

--- a/src/zyra/wizard/zyra_capabilities/run.json
+++ b/src/zyra/wizard/zyra_capabilities/run.json
@@ -143,6 +143,12 @@
     ],
     "domain": "run",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.pipeline_runner",
+      "callable": "_cmd"
+    },
+    "returns": "object",
+    "stdin_arg": "config"
   }
 }

--- a/src/zyra/wizard/zyra_capabilities/search.json
+++ b/src/zyra/wizard/zyra_capabilities/search.json
@@ -143,6 +143,12 @@
     "positionals": [],
     "domain": "search",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.connectors.discovery",
+      "callable": "_cmd_api"
+    },
+    "returns": "bytes",
+    "output_arg": "--output"
   }
 }

--- a/src/zyra/wizard/zyra_capabilities/simulate.json
+++ b/src/zyra/wizard/zyra_capabilities/simulate.json
@@ -34,6 +34,11 @@
         "trials"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.simulate",
+      "callable": "_cmd_sample"
+    },
+    "returns": "path"
   }
 }

--- a/src/zyra/wizard/zyra_capabilities/transform.json
+++ b/src/zyra/wizard/zyra_capabilities/transform.json
@@ -102,7 +102,12 @@
     "positionals": [],
     "domain": "transform",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_enrich_datasets"
+    },
+    "returns": "path"
   },
   "transform enrich-metadata": {
     "description": "Enrich a frames metadata JSON with dataset_id, Vimeo URI, and updated_at; read from file or stdin.",
@@ -169,7 +174,12 @@
     "positionals": [],
     "domain": "transform",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_enrich"
+    },
+    "returns": "path"
   },
   "transform metadata": {
     "description": "Scan a frames directory to compute start/end timestamps, counts, and missing frames on a cadence.",
@@ -230,7 +240,12 @@
     "positionals": [],
     "domain": "transform",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_metadata"
+    },
+    "returns": "bytes"
   },
   "transform scan-frames": {
     "description": "Alias of 'metadata'. Scan a frames directory and report timestamps, counts, and missing frames.",
@@ -291,7 +306,12 @@
     "positionals": [],
     "domain": "transform",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_metadata"
+    },
+    "returns": "bytes"
   },
   "transform update-dataset-json": {
     "description": "Update a dataset.json entry by id using metadata (start/end and Vimeo URI) from a file, stdin, or args.",
@@ -374,6 +394,11 @@
     "positionals": [],
     "domain": "transform",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.transform",
+      "callable": "_cmd_update_dataset"
+    },
+    "returns": "path"
   }
 }

--- a/src/zyra/wizard/zyra_capabilities/verify.json
+++ b/src/zyra/wizard/zyra_capabilities/verify.json
@@ -34,6 +34,11 @@
         "metric"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.verify",
+      "callable": "_cmd_evaluate"
+    },
+    "returns": "text"
   }
 }

--- a/src/zyra/wizard/zyra_capabilities/visualize.json
+++ b/src/zyra/wizard/zyra_capabilities/visualize.json
@@ -263,7 +263,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_animate",
+      "callable": "handle_animate"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render compose-video": {
     "description": "zyra render compose-video",
@@ -325,7 +334,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_compose_video",
+      "callable": "handle_compose_video"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render contour": {
     "description": "zyra render contour",
@@ -511,7 +529,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_contour",
+      "callable": "handle_contour"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render heatmap": {
     "description": "zyra render heatmap",
@@ -685,7 +712,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_heatmap",
+      "callable": "handle_heatmap"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render interactive": {
     "description": "zyra render interactive",
@@ -853,7 +889,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_interactive",
+      "callable": "handle_interactive"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render timeseries": {
     "description": "zyra render timeseries",
@@ -945,7 +990,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_timeseries",
+      "callable": "handle_timeseries"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "render vector": {
     "description": "zyra render vector",
@@ -1115,7 +1169,16 @@
     "positionals": [],
     "domain": "render",
     "args_schema": null,
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_vector",
+      "callable": "handle_vector"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize animate": {
     "description": "zyra visualize animate",
@@ -1405,7 +1468,16 @@
         "width"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_animate",
+      "callable": "handle_animate"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize compose-video": {
     "description": "zyra visualize compose-video",
@@ -1476,7 +1548,16 @@
         "fps"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_compose_video",
+      "callable": "handle_compose_video"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize contour": {
     "description": "zyra visualize contour",
@@ -1673,7 +1754,16 @@
         "output_dir"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_contour",
+      "callable": "handle_contour"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize heatmap": {
     "description": "zyra visualize heatmap",
@@ -1875,7 +1965,16 @@
     "example_args": {
       "input": "samples/demo.npy",
       "output": "/tmp/heatmap.png"
-    }
+    },
+    "impl": {
+      "module": "zyra.visualization.cli_heatmap",
+      "callable": "handle_heatmap"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize interactive": {
     "description": "zyra visualize interactive",
@@ -2087,7 +2186,16 @@
         "zoom"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_interactive",
+      "callable": "handle_interactive"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize timeseries": {
     "description": "zyra visualize timeseries",
@@ -2196,7 +2304,16 @@
         "ylabel"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_timeseries",
+      "callable": "handle_timeseries"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   },
   "visualize vector": {
     "description": "zyra visualize vector",
@@ -2393,6 +2510,15 @@
         "xarray_engine"
       ]
     },
-    "example_args": null
+    "example_args": null,
+    "impl": {
+      "module": "zyra.visualization.cli_vector",
+      "callable": "handle_vector"
+    },
+    "returns": "path",
+    "output_arg": "--output",
+    "extras": [
+      "visualization"
+    ]
   }
 }

--- a/tests/cli/test_manifest_smoke.py
+++ b/tests/cli/test_manifest_smoke.py
@@ -18,3 +18,15 @@ def test_manifest_contains_core_groups():
         "manifest missing expected core commands: "
         f"acquire={has_acquire}, visualize={has_visualize}"
     )
+
+
+def test_manifest_includes_impl_and_returns_hints():
+    """Selected entries should carry impl metadata and return hints."""
+    from zyra.wizard.manifest import build_manifest
+
+    mf = build_manifest()
+    sample = mf.get("acquire http") or {}
+    assert isinstance(sample.get("impl"), dict)
+    assert sample.get("impl", {}).get("module")
+    assert sample.get("impl", {}).get("callable")
+    assert isinstance(sample.get("returns"), str)

--- a/tests/notebook/test_registry.py
+++ b/tests/notebook/test_registry.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from zyra.notebook.registry import create_session
+
+
+def test_session_builds_stage_namespaces():
+    sess = create_session()
+
+    # Ensure core namespaces exist
+    assert hasattr(sess, "acquire")
+    assert hasattr(sess, "process")
+    assert hasattr(sess, "visualize")
+    assert hasattr(sess, "narrate")
+
+    # Ensure known tool mapping is present
+    assert "http" in dir(sess.acquire)
+    assert "convert_format" in dir(sess.process)
+
+
+def test_session_allows_custom_workdir(tmp_path):
+    sess = create_session(workdir=tmp_path)
+    assert sess.workspace() == tmp_path
+
+
+def test_tool_wrapper_invokes_impl():
+    manifest = {
+        "process echo": {
+            "impl": {
+                "module": "zyra.notebook.registry",
+                "callable": "_noop_tool",
+            },
+            "returns": "object",
+        }
+    }
+    sess = create_session(manifest=manifest)
+    out = sess.process.echo(value="ok", extra=1)
+    assert out["value"] == "ok"
+    assert out["extra"] == 1
+
+
+def test_tool_wrapper_missing_impl_raises():
+    manifest = {"process nope": {"returns": "object"}}
+    sess = create_session(manifest=manifest)
+    with pytest.raises(NotImplementedError):
+        sess.process.nope()
+
+
+def test_provenance_path_defaults(tmp_path, monkeypatch):
+    monkeypatch.setenv("ZYRA_NOTEBOOK_DIR", str(tmp_path))
+    sess = create_session()
+    assert sess.provenance_store() is not None
+    # default path under workdir
+    assert (tmp_path / "provenance.sqlite") == sess._provenance_path  # noqa: SLF001
+
+
+def test_inline_register_executes():
+    sess = create_session(manifest={})
+
+    def _adder(ns):
+        return ns.a + ns.b
+
+    sess.process.register("add", _adder, returns="object")
+    assert sess.process.add(a=2, b=3) == 5
+
+
+def test_provenance_logs_without_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("ZYRA_NOTEBOOK_DIR", str(tmp_path))
+    sess = create_session(manifest={})
+
+    def _echo(ns):
+        return ns.value
+
+    sess.process.register("echo", _echo, returns="object")
+    # Should not raise even if store is null; placeholder ensures call path runs
+    assert sess.process.echo(value="hi") == "hi"
+
+
+def test_pipeline_and_cli_exports():
+    sess = create_session(manifest={})
+
+    def _adder(ns):
+        return ns.a + ns.b
+
+    sess.process.register("add", _adder, returns="object")
+    sess.process.add(a=1, b=2)
+    pipeline = sess.to_pipeline()
+    assert pipeline == [
+        {"stage": "process", "command": "add", "args": {"a": 1, "b": 2}}
+    ]
+    cli = sess.to_cli()
+    assert cli[0].startswith("zyra process add")
+    assert "--a 1" in cli[0]
+    assert "--b 2" in cli[0]


### PR DESCRIPTION
This pull request introduces notebook-friendly scaffolding across the Zyra codebase, enabling easier integration and execution of Zyra workflows in notebook environments. The main changes include the addition of a new `zyra.notebook` package with documentation and APIs, enhancements to manifest metadata for notebook compatibility, and new entrypoints and helpers for running commands and processing data from notebook code.

**Notebook integration and scaffolding:**

* Added the new `zyra.notebook` package, including a `README.md` with usage examples, workflow guidance, and limitations, and an `__init__.py` that exposes `Session` and `create_session` for notebook-friendly execution. [[1]](diffhunk://#diff-53c66b5b56d0f1118fc0da2d6a70fac657cfe6764c12858387f5f4b58369b64cR1-R50) [[2]](diffhunk://#diff-6bb45dce2fbe0dc627dae625e6e00429be0113faf69da4604a331b12945f73e8R1-R19)

**Manifest and metadata improvements for notebook UX:**

* Extended manifest generation in `zyra/wizard/manifest.py` to include notebook-friendly hints, such as return types, output argument names, side effects, and direct callable references for each command, improving notebook introspection and automation. [[1]](diffhunk://#diff-1c016872d7104eb603c8740341acfd807742cbc125f791b5aed2c9eec282351cR41-R230) [[2]](diffhunk://#diff-1c016872d7104eb603c8740341acfd807742cbc125f791b5aed2c9eec282351cL545-R768) [[3]](diffhunk://#diff-1c016872d7104eb603c8740341acfd807742cbc125f791b5aed2c9eec282351cR782-R789)
* Updated generated capability JSON files (e.g., `acquire.json`) to include implementation references, return types, and output argument metadata for each command. [[1]](diffhunk://#diff-631ead6e7e4ff00b5d1cd6f2cad136a622397d4480b9d383894addfe47bd00adL271-R277) [[2]](diffhunk://#diff-631ead6e7e4ff00b5d1cd6f2cad136a622397d4480b9d383894addfe47bd00adL387-R402) [[3]](diffhunk://#diff-631ead6e7e4ff00b5d1cd6f2cad136a622397d4480b9d383894addfe47bd00adL505-R529)

**Notebook-friendly command and processing entrypoints:**

* Added `notebook_swarm` and related helpers to `zyra.narrate` for running swarm narration directly from notebook code, with improved error handling, output cleaning, and fallback narration logic. [[1]](diffhunk://#diff-4c9d6522d3178c0482e806a02c49e7f965e80beb37cfcb5945f008899f7df5b5R202-R205) [[2]](diffhunk://#diff-4c9d6522d3178c0482e806a02c49e7f965e80beb37cfcb5945f008899f7df5b5L227-R273) [[3]](diffhunk://#diff-4c9d6522d3178c0482e806a02c49e7f965e80beb37cfcb5945f008899f7df5b5L270-R374) [[4]](diffhunk://#diff-4c9d6522d3178c0482e806a02c49e7f965e80beb37cfcb5945f008899f7df5b5L415-R547)
* Added `notebook_pad_missing` to `zyra.processing` as a notebook-friendly shim for the pad-missing workflow, and exposed the main handler for notebook/manifest imports. [[1]](diffhunk://#diff-0cb809cdb5ca5562fa7a8755d2085728bfc1a27fb7d71284b0503eb49cad8985R66-R82) [[2]](diffhunk://#diff-0cb809cdb5ca5562fa7a8755d2085728bfc1a27fb7d71284b0503eb49cad8985R399-R401)

These changes collectively improve Zyra's usability in interactive notebook environments, streamline command introspection, and enable direct invocation of core workflows from Python code.