### PR TITLE
Codex Relay: zyra-project/zyra PR #116 — fix(ci): include print poster in GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -45,6 +45,7 @@ jobs:
           python poster/scripts/build_poster.py
           mkdir -p docs/build/poster
           cp poster/html/zyra-poster.html docs/build/poster/
+          cp poster/html/zyra-poster-print.html docs/build/poster/
           cp poster/html/*.png docs/build/poster/
 
       - name: Upload Pages artifact


### PR DESCRIPTION
Mirrored from **zyra-project/zyra** PR #116

Source: https://github.com/zyra-project/zyra/pull/116

> This PR is maintained by an automated relay. Changes should be made in the original downstream PR.