### PR TITLE
Codex Relay: zyra-project/zyra PR #254 — Carry georeferencing into GeoTIFF conversion from GRIB grid metadata

### DIFF
--- a/src/zyra/processing/grib_utils.py
+++ b/src/zyra/processing/grib_utils.py
@@ -505,7 +505,6 @@ def convert_to_format(
             georef = _grib_georeference(data_array)
             if georef is not None:
                 import numpy as np  # type: ignore
-                import rasterio  # type: ignore
                 from rasterio.io import MemoryFile
 
                 crs, transform, flip = georef

--- a/src/zyra/processing/grib_utils.py
+++ b/src/zyra/processing/grib_utils.py
@@ -226,6 +226,79 @@ def extract_variable(decoded: DecodedGRIB, var_name: str) -> Any:
     raise RuntimeError("Unsupported decoded structure for variable extraction.")
 
 
+def _grib_georeference(da: Any) -> tuple[Any, Any, bool] | None:
+    """Derive ``(crs, transform, flip_rows)`` from cfgrib ``GRIB_*`` attrs.
+
+    Supports ``regular_ll`` and ``lambert`` grids (the NOAA projected
+    products — HRRR, NAM, RRFS — are Lambert). Returns ``None`` for
+    unrecognized grid types or incomplete metadata; callers keep their
+    previous (ungeoreferenced) behavior in that case.
+
+    ``flip_rows`` is True when the GRIB scans south-first
+    (``jScansPositively=1``) and rows must be flipped to GeoTIFF's
+    north-up convention.
+
+    Notes
+    -----
+    cfgrib does not expose the earth radius; the GRIB2 sphere default
+    of 6371229 m (shapeOfTheEarth=6) is assumed for projected grids,
+    which matches NOAA's operational products.
+    """
+    attrs = getattr(da, "attrs", {}) or {}
+    grid_type = attrs.get("GRIB_gridType")
+    try:
+        from rasterio.crs import CRS
+        from rasterio.transform import from_origin
+    except ImportError:
+        return None
+    try:
+        ny = int(attrs["GRIB_Ny"])
+        flip = bool(attrs.get("GRIB_jScansPositively", 0))
+        lat_first = float(attrs["GRIB_latitudeOfFirstGridPointInDegrees"])
+        lon_first = float(attrs["GRIB_longitudeOfFirstGridPointInDegrees"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if lon_first > 180.0:
+        lon_first -= 360.0
+
+    if grid_type == "regular_ll":
+        try:
+            dlon = float(attrs["GRIB_iDirectionIncrementInDegrees"])
+            dlat = float(attrs["GRIB_jDirectionIncrementInDegrees"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        north = (lat_first + (ny - 1) * dlat) if flip else lat_first
+        transform = from_origin(lon_first - dlon / 2, north + dlat / 2, dlon, dlat)
+        return CRS.from_epsg(4326), transform, flip
+
+    if grid_type == "lambert":
+        try:
+            import pyproj
+
+            dx = float(attrs["GRIB_DxInMetres"])
+            dy = float(attrs["GRIB_DyInMetres"])
+            crs = CRS.from_dict(
+                {
+                    "proj": "lcc",
+                    "lat_1": float(attrs["GRIB_Latin1InDegrees"]),
+                    "lat_2": float(attrs["GRIB_Latin2InDegrees"]),
+                    "lat_0": float(attrs["GRIB_LaDInDegrees"]),
+                    "lon_0": float(attrs["GRIB_LoVInDegrees"]),
+                    "R": 6371229.0,
+                }
+            )
+            tr = pyproj.Transformer.from_crs("EPSG:4326", crs, always_xy=True)
+            x_first, y_first = tr.transform(lon_first, lat_first)
+            # (x_first, y_first) is the center of the first grid point.
+            west = x_first - dx / 2
+            top_center = y_first + (ny - 1) * dy if flip else y_first
+            transform = from_origin(west, top_center + dy / 2, dx, dy)
+            return crs, transform, flip
+        except Exception:
+            return None
+    return None
+
+
 def convert_to_format(
     decoded: DecodedGRIB,
     format_type: str,
@@ -419,13 +492,47 @@ def convert_to_format(
                 raise ValueError(
                     "GeoTIFF conversion supports a single variable. Provide 'var' to select one."
                 )
-            # Use rioxarray if available; otherwise rasterio
-            data_array = obj if hasattr(obj, "rio") else None
+            data_array = obj
+            if hasattr(data_array, "data_vars"):
+                # A Dataset (single variable — enforced above): take the
+                # variable itself so the GRIB_* attrs are visible; cfgrib
+                # stores grid metadata on variables, not the dataset.
+                data_array = data_array[next(iter(data_array.data_vars))]
+            # Prefer explicit georeferencing derived from the GRIB grid
+            # metadata: rioxarray's to_raster writes no CRS/transform for
+            # cfgrib datasets (2D lat/lon coords), and GRIB scan order
+            # (south-first) must be normalized to GeoTIFF north-up.
+            georef = _grib_georeference(data_array)
+            if georef is not None:
+                import numpy as np  # type: ignore
+                import rasterio  # type: ignore
+                from rasterio.io import MemoryFile
+
+                crs, transform, flip = georef
+                values = np.squeeze(np.asarray(data_array.values))
+                if values.ndim != 2:
+                    raise ValueError(
+                        "GeoTIFF conversion needs a single 2D field; select one "
+                        "level/time with 'var' or extract-variable first."
+                    )
+                if flip:
+                    values = values[::-1, :]
+                profile = {
+                    "driver": "GTiff",
+                    "width": values.shape[1],
+                    "height": values.shape[0],
+                    "count": 1,
+                    "dtype": values.dtype.name,
+                    "crs": crs,
+                    "transform": transform,
+                }
+                with MemoryFile() as mem:
+                    with mem.open(**profile) as dst:
+                        dst.write(values, 1)
+                    return mem.read()
             try:
-                if data_array is None and hasattr(ds, "to_array"):
-                    # If obj is a Dataset, pick the first variable
-                    data_array = ds.to_array().isel(variable=0)
-                # Ensure rioxarray is available
+                # Fallback: rioxarray for data that carries its own
+                # georeferencing via the rio accessor.
                 import rioxarray  # noqa: F401  # type: ignore
 
                 tmp = tempfile.NamedTemporaryFile(suffix=".tif", delete=False)

--- a/tests/processing/test_grib_georeference.py
+++ b/tests/processing/test_grib_georeference.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 xr = pytest.importorskip("xarray")
-rasterio = pytest.importorskip("rasterio")
+pytest.importorskip("rasterio")
 pytest.importorskip("pyproj")
 
 from zyra.processing.grib_utils import (  # noqa: E402

--- a/tests/processing/test_grib_georeference.py
+++ b/tests/processing/test_grib_georeference.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GeoTIFF conversion must carry georeferencing derived from GRIB attrs.
+
+Previously `convert-format geotiff` wrote correct pixels with no CRS,
+an identity transform, and GRIB scan order (south-first → upside-down
+image). The attrs below mirror a real HRRR composite-reflectivity
+message from the public noaa-hrrr-bdp-pds bucket.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+xr = pytest.importorskip("xarray")
+rasterio = pytest.importorskip("rasterio")
+pytest.importorskip("pyproj")
+
+from zyra.processing.grib_utils import (  # noqa: E402
+    DecodedGRIB,
+    _grib_georeference,
+    convert_to_format,
+)
+
+HRRR_ATTRS = {
+    "GRIB_gridType": "lambert",
+    "GRIB_Nx": 1799,
+    "GRIB_Ny": 1059,
+    "GRIB_DxInMetres": 3000.0,
+    "GRIB_DyInMetres": 3000.0,
+    "GRIB_Latin1InDegrees": 38.5,
+    "GRIB_Latin2InDegrees": 38.5,
+    "GRIB_LaDInDegrees": 38.5,
+    "GRIB_LoVInDegrees": 262.5,
+    "GRIB_jScansPositively": 1,
+    "GRIB_latitudeOfFirstGridPointInDegrees": 21.138123,
+    "GRIB_longitudeOfFirstGridPointInDegrees": 237.280472,
+}
+# Projected bounds of the HRRR CONUS grid, verified against the live
+# message with pygrib (corner center minus half a cell).
+HRRR_WEST, HRRR_NORTH = -2699020.1, 1588193.8
+
+
+def _hrrr_like_array(ny=6, nx=9):
+    attrs = dict(HRRR_ATTRS)
+    attrs["GRIB_Ny"], attrs["GRIB_Nx"] = ny, nx
+    data = np.arange(ny * nx, dtype="float32").reshape(ny, nx)
+    return xr.DataArray(data, dims=("y", "x"), attrs=attrs)
+
+
+def test_lambert_georeference_matches_live_hrrr_values():
+    da = _hrrr_like_array(ny=1059, nx=1799)
+    georef = _grib_georeference(da)
+    assert georef is not None
+    crs, transform, flip = georef
+    assert flip is True
+    d = crs.to_dict()
+    assert d["proj"] == "lcc"
+    assert d["lon_0"] == pytest.approx(262.5)
+    assert transform.c == pytest.approx(HRRR_WEST, abs=1.0)  # west edge
+    assert transform.f == pytest.approx(HRRR_NORTH, abs=1.0)  # north edge
+    assert transform.a == pytest.approx(3000.0)
+
+
+def test_regular_ll_georeference():
+    attrs = {
+        "GRIB_gridType": "regular_ll",
+        "GRIB_Nx": 360,
+        "GRIB_Ny": 181,
+        "GRIB_iDirectionIncrementInDegrees": 1.0,
+        "GRIB_jDirectionIncrementInDegrees": 1.0,
+        "GRIB_jScansPositively": 0,
+        "GRIB_latitudeOfFirstGridPointInDegrees": 90.0,
+        "GRIB_longitudeOfFirstGridPointInDegrees": 0.0,
+    }
+    da = xr.DataArray(
+        np.zeros((181, 360), dtype="float32"), dims=("y", "x"), attrs=attrs
+    )
+    crs, transform, flip = _grib_georeference(da)
+    assert crs.to_epsg() == 4326
+    assert flip is False
+    assert transform.f == pytest.approx(90.5)
+    assert transform.c == pytest.approx(-0.5)
+
+
+def test_unknown_grid_returns_none():
+    da = xr.DataArray(np.zeros((4, 4)), dims=("y", "x"), attrs={"GRIB_gridType": "??"})
+    assert _grib_georeference(da) is None
+
+
+def test_convert_geotiff_carries_georeference_and_north_up():
+    da = _hrrr_like_array(ny=6, nx=9)
+    ds = xr.Dataset({"refc": da})
+    decoded = DecodedGRIB(backend="cfgrib", dataset=ds)
+    tif_bytes = convert_to_format(decoded, "geotiff")
+    from rasterio.io import MemoryFile
+
+    with MemoryFile(tif_bytes) as mem, mem.open() as out:
+        assert out.crs is not None
+        assert not out.transform.is_identity
+        a = out.read(1)
+    # South-first GRIB rows must come out north-up: the source's last
+    # row (values 45..53 for the 6x9 grid) is the image's first row.
+    assert a[0, 0] == pytest.approx(45.0)
+    assert a[-1, 0] == pytest.approx(0.0)


### PR DESCRIPTION
Mirrored from **zyra-project/zyra** PR #254

Source: https://github.com/zyra-project/zyra/pull/254

> This PR is maintained by an automated relay. Changes should be made in the original downstream PR.