### PR TITLE
Codex Relay: zyra-project/zyra PR #280 — Floor max_attempts at 1, and stop overclaiming API/CLI parity

### DIFF
--- a/src/zyra/api/schemas/domain_args.py
+++ b/src/zyra/api/schemas/domain_args.py
@@ -131,9 +131,13 @@ class VisualizeHeatmapArgs(BaseModel):
 def _validate_batch_output_names(model):
     """Shared CLI-parity checks for ``output_names``.
 
-    Delegates to the same helper the CLI handlers call, so the two
-    surfaces cannot drift: a request the API accepts is one the handler
-    will accept, with the same message if it does not.
+    Count, uniqueness and the filename rule come from the same helper
+    the CLI handlers call, so the two surfaces cannot drift on what
+    they accept, and those three report identically.
+
+    The missing-``inputs`` case is checked here instead, and worded for
+    this surface: a JSON body has no ``--inputs`` flag to point at, so
+    the message names the fields. Same rule, different vocabulary.
 
     Only the supplied case is checked here. When ``output_names`` is
     absent the names are derived, and only the handler knows the output

--- a/src/zyra/connectors/backends/http.py
+++ b/src/zyra/connectors/backends/http.py
@@ -24,11 +24,17 @@ from zyra.connectors.backends._retry import (
 
 
 def _retry_opts() -> dict[str, Any]:
-    """Retry knobs, overridable per deployment without a code change."""
+    """Retry knobs, overridable per deployment without a code change.
+
+    ``max_attempts`` is floored at 1, as ``default_max_workers`` floors
+    concurrency: ``ZYRA_HTTP_MAX_ATTEMPTS=0`` is a reasonable way to
+    write "do not retry", and it should mean one attempt rather than
+    raise out of the fetch path for every request.
+    """
     from zyra.utils.env import env_int
 
     return {
-        "max_attempts": env_int("HTTP_MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS),
+        "max_attempts": max(1, env_int("HTTP_MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS)),
         "base_delay": DEFAULT_BASE_DELAY,
         "max_delay": DEFAULT_MAX_DELAY,
     }

--- a/tests/cli/test_batch_output_names.py
+++ b/tests/cli/test_batch_output_names.py
@@ -342,3 +342,81 @@ def test_cli_length_mismatch_exits_2(tmp_path):
     assert proc.returncode == 2, proc.stderr
     assert "one entry per --inputs" in proc.stderr
     assert "Traceback" not in proc.stderr
+
+
+def test_shared_rules_report_identically_on_both_surfaces():
+    """The parity claim in `_validate_batch_output_names`, checked.
+
+    The three shared rules must produce the *same* message from the API
+    and the CLI — that is what "cannot drift" means. The missing-inputs
+    case deliberately differs, because a JSON body has no `--inputs`
+    flag to name; the docstring says so, and this pins both halves so
+    the claim stays true.
+    """
+    import re
+
+    from pydantic import ValidationError
+
+    from zyra.api.schemas.domain_args import VisualizeHeatmapArgs
+
+    def api_message(**kwargs) -> str:
+        try:
+            VisualizeHeatmapArgs(**kwargs)
+        except ValidationError as exc:
+            # Pydantic wraps it: a count line, then "Value error, <msg>
+            # [type=...]". DOTALL so the leading line is consumed too.
+            return re.sub(r".*Value error, ", "", str(exc), flags=re.DOTALL).split(
+                " [type"
+            )[0]
+        raise AssertionError("expected a validation error")
+
+    def cli_message(argv) -> str:
+        proc = subprocess.run(
+            [sys.executable, "-m", "zyra.cli", "visualize", "heatmap", *argv],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 2, proc.stderr
+        # The logger prefix varies with configuration ("ERROR: " here,
+        # "ERROR:root:" under the default root logger).
+        return re.sub(r"^ERROR(:root)?:\s*", "", proc.stderr.strip())
+
+    shared = [
+        (
+            {"inputs": ["a", "b"], "output_dir": "o", "output_names": ["one.png"]},
+            ["--inputs", "a", "b", "--output-dir", "o", "--output-names", "one.png"],
+        ),
+        (
+            {
+                "inputs": ["a", "b"],
+                "output_dir": "o",
+                "output_names": ["s.png", "s.png"],
+            },
+            [
+                "--inputs",
+                "a",
+                "b",
+                "--output-dir",
+                "o",
+                "--output-names",
+                "s.png",
+                "s.png",
+            ],
+        ),
+        (
+            {"inputs": ["a"], "output_dir": "o", "output_names": ["sub/x.png"]},
+            ["--inputs", "a", "--output-dir", "o", "--output-names", "sub/x.png"],
+        ),
+    ]
+    for kwargs, argv in shared:
+        assert api_message(**kwargs) == cli_message(argv)
+
+    # The documented exception: same rule, surface-appropriate wording.
+    api_only = api_message(input="a.tif", output="b.png", output_names=["x.png"])
+    cli_only = cli_message(
+        ["--input", "a.tif", "--output", "b.png", "--output-names", "x.png"]
+    )
+    assert api_only != cli_only
+    assert "inputs" in api_only and "--inputs" not in api_only
+    assert "--inputs" in cli_only

--- a/tests/connectors/test_http_retry.py
+++ b/tests/connectors/test_http_retry.py
@@ -364,3 +364,46 @@ def test_refused_survives_a_self_referential_cause_chain():
     a.__cause__ = b
     b.__cause__ = a
     assert is_retryable(a) is True
+
+
+@pytest.mark.parametrize(("env", "expected"), [("0", 1), ("-3", 1), ("", 5), ("2", 2)])
+def test_max_attempts_is_floored_at_one(monkeypatch, env, expected):
+    """`ZYRA_HTTP_MAX_ATTEMPTS=0` must mean one attempt, not a crash.
+
+    with_retries rejects max_attempts < 1, so an unfloored env value
+    turned "do not retry" — a reasonable reading of 0 — into a
+    ValueError raised out of every fetch, before any request was made.
+    default_max_workers already floors the same way.
+    """
+    from zyra.connectors.backends import http as http_backend
+
+    if env:
+        monkeypatch.setenv("ZYRA_HTTP_MAX_ATTEMPTS", env)
+    else:
+        monkeypatch.delenv("ZYRA_HTTP_MAX_ATTEMPTS", raising=False)
+    assert http_backend._retry_opts()["max_attempts"] == expected
+
+
+def test_zero_attempts_still_makes_exactly_one_request(monkeypatch):
+    """The floor has to hold at the fetch path, not just in the opts.
+
+    Patches only ``requests.get`` — deliberately not via
+    ``_patch_requests_get``, which substitutes its own ``_retry_opts``
+    and would hide the very thing under test.
+    """
+    requests = pytest.importorskip("requests")
+    from zyra.connectors.backends import http as http_backend
+
+    monkeypatch.setenv("ZYRA_HTTP_MAX_ATTEMPTS", "0")
+    calls = {"n": 0}
+
+    def _get(url, **kw):
+        calls["n"] += 1
+        raise _HTTPError(503)
+
+    monkeypatch.setattr(requests, "get", _get)
+    with pytest.raises(Exception) as excinfo:
+        http_backend.fetch_bytes("https://example.org/x")
+    # A 503 should surface, not "max_attempts must be >= 1".
+    assert "max_attempts" not in str(excinfo.value), "floor was not applied"
+    assert calls["n"] == 1, "0 must mean one attempt, not zero and not five"


### PR DESCRIPTION
Mirrored from **zyra-project/zyra** PR #280

Source: https://github.com/zyra-project/zyra/pull/280

> This PR is maintained by an automated relay. Changes should be made in the original downstream PR.