### PR TITLE
Codex Relay: zyra-project/zyra PR #288 — Validate --extent latitudes and name the other flag's ordering

### DIFF
--- a/src/zyra/visualization/cli_register.py
+++ b/src/zyra/visualization/cli_register.py
@@ -52,7 +52,7 @@ def register_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: -180 180 -90 90)",
+        help="west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     p_hm.add_argument(
         "--output",
@@ -218,7 +218,7 @@ def register_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: -180 180 -90 90)",
+        help="west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     # Not required=True: --inputs/--output-dir is the documented batch
     # mode (see this flag's own help), and an argparse-level requirement
@@ -350,7 +350,7 @@ def register_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: -180 180 -90 90)",
+        help="west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     p_vec.add_argument("--width", type=int, default=1024)
     p_vec.add_argument("--height", type=int, default=512)
@@ -409,7 +409,7 @@ def register_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: -180 180 -90 90)",
+        help="west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     p_anim.add_argument("--width", type=int, default=1024)
     p_anim.add_argument("--height", type=int, default=512)
@@ -528,7 +528,7 @@ def register_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: -180 180 -90 90)",
+        help="west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     p_int.add_argument("--width", type=int, default=1024)
     p_int.add_argument("--height", type=int, default=512)

--- a/src/zyra/visualization/cli_sos.py
+++ b/src/zyra/visualization/cli_sos.py
@@ -202,7 +202,7 @@ def register_sos_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: global -180 180 -90 90)",
+        help="west east south north (default: global -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     p_sos.add_argument("--width", type=int, default=4096, help="Output width (px)")
     p_sos.add_argument("--height", type=int, default=2048, help="Output height (px)")

--- a/src/zyra/visualization/cli_utils.py
+++ b/src/zyra/visualization/cli_utils.py
@@ -324,9 +324,9 @@ def resolve_extent(ns) -> list[float]:
     (``styles.DEFAULT_EXTENT``) when unset.
 
     Exits with code 2 (message on stderr via logging) on a wrong-length
-    value. The numeric exit code keeps the failure a clean exit-status
-    signal rather than relying on the Domain API executor's message-string
-    handling.
+    value, or on one whose bounds are inverted — see below. The numeric
+    exit code keeps the failure a clean exit-status signal rather than
+    relying on the Domain API executor's message-string handling.
     """
     extent = getattr(ns, "extent", None)
     if extent is None:
@@ -336,7 +336,51 @@ def resolve_extent(ns) -> list[float]:
 
         logging.error("--extent takes exactly 4 values: west east south north")
         raise SystemExit(2)
-    return [float(v) for v in extent]
+    west, east, south, north = (float(v) for v in extent)
+    # `--extent` is [west, east, south, north] (matplotlib's `imshow`
+    # order) while `process reproject --dst-bounds` is [west, south,
+    # east, north] (the GDAL/rasterio bbox order). A regional pipeline
+    # writes both, adjacent, so passing one in the other's order is easy
+    # and silent — four plausible numbers rendering a valid picture of
+    # the wrong part of the world (#287).
+    #
+    # It cannot be detected in general: both orderings can describe a
+    # perfectly well-formed box, and `-135 21 -60 53` is exactly that
+    # either way round. What *is* checkable is that the two values in
+    # the latitude slots really are latitudes — a longitude landing
+    # there is the common tell, since longitudes routinely exceed ±90
+    # while latitudes never do.
+    for name, value in (("south", south), ("north", north)):
+        if not -90.0 <= value <= 90.0:
+            import logging
+
+            logging.error(
+                "--extent takes west east south north; %s=%g is not a valid "
+                "latitude. Note that `process reproject --dst-bounds` uses a "
+                "different order (west south east north) — did you mean "
+                "--extent %g %g %g %g?",
+                name,
+                value,
+                west,
+                south,
+                east,
+                north,
+            )
+            raise SystemExit(2)
+    # Latitudes do not wrap, so an inverted pair is always an error.
+    # Longitudes deliberately are not checked: west > east is how a
+    # dateline-crossing extent is written.
+    if north <= south:
+        import logging
+
+        logging.error(
+            "--extent takes west east south north; south=%g is not below "
+            "north=%g, so the extent is empty",
+            south,
+            north,
+        )
+        raise SystemExit(2)
+    return [west, east, south, north]
 
 
 def features_from_ns(ns) -> list[str] | None:

--- a/src/zyra/wizard/zyra_capabilities.json
+++ b/src/zyra/wizard/zyra_capabilities.json
@@ -3202,7 +3202,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -3462,7 +3462,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -3797,7 +3797,7 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -4039,7 +4039,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -4409,7 +4409,7 @@
         "default": 3
       },
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -4582,7 +4582,7 @@
       },
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
-        "help": "west east south north (default: global -180 180 -90 90)",
+        "help": "west east south north (default: global -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -4708,7 +4708,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -4935,7 +4935,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -5237,7 +5237,7 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -5452,7 +5452,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -5787,7 +5787,7 @@
         "default": 3
       },
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -5916,7 +5916,7 @@
       },
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
-        "help": "west east south north (default: global -180 180 -90 90)",
+        "help": "west east south north (default: global -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {

--- a/src/zyra/wizard/zyra_capabilities/visualize.json
+++ b/src/zyra/wizard/zyra_capabilities/visualize.json
@@ -110,7 +110,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -426,7 +426,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -621,7 +621,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -867,7 +867,7 @@
         "default": 3
       },
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -996,7 +996,7 @@
       },
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
-        "help": "west east south north (default: global -180 180 -90 90)",
+        "help": "west east south north (default: global -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -1229,7 +1229,7 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -1444,7 +1444,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -1795,7 +1795,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -2006,7 +2006,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -2285,7 +2285,7 @@
         "default": 3
       },
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -2458,7 +2458,7 @@
       },
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
-        "help": "west east south north (default: global -180 180 -90 90)",
+        "help": "west east south north (default: global -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -2708,7 +2708,7 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {

--- a/tests/visualization/test_extent_flags.py
+++ b/tests/visualization/test_extent_flags.py
@@ -88,3 +88,64 @@ def test_api_argv_round_trips_extent():
     assert argv[:2] == ["visualize", "heatmap"]
     ns = _parser().parse_args(argv[1:])
     assert ns.extent == [-120.0, -60.0, 20.0, 55.0]
+
+
+class TestExtentValueValidation:
+    """`--extent` value checks (#287).
+
+    `--extent` is [west, east, south, north]; `process reproject
+    --dst-bounds` is [west, south, east, north]. A regional pipeline
+    writes both, adjacent, and passing one in the other's order renders
+    a valid picture of the wrong part of the world with no error.
+
+    The swap is not detectable in general — both orderings can describe
+    a well-formed box — so these check the part that is: the two values
+    in the latitude slots have to be latitudes.
+    """
+
+    @pytest.mark.parametrize(
+        ("extent", "why"),
+        [
+            ([-135.0, -60.0, 21.0, 53.0], "a regional box"),
+            ([-180.0, 180.0, -90.0, 90.0], "the global default"),
+            # west > east is how a dateline-crossing extent is written,
+            # so longitudes are deliberately not order-checked.
+            ([170.0, -170.0, -10.0, 10.0], "crossing the dateline"),
+        ],
+    )
+    def test_valid_extents_are_accepted(self, extent, why):
+        assert resolve_extent(SimpleNamespace(extent=list(extent))) == list(extent), why
+
+    @pytest.mark.parametrize(
+        ("extent", "why"),
+        [
+            ([-135.0, 21.0, -160.0, 53.0], "a longitude in the south slot"),
+            ([0.0, 10.0, -95.0, 95.0], "latitudes beyond the poles"),
+            ([-135.0, -60.0, 53.0, 21.0], "south above north — an empty box"),
+        ],
+    )
+    def test_invalid_extents_exit_2(self, extent, why):
+        with pytest.raises(SystemExit) as exc:
+            resolve_extent(SimpleNamespace(extent=list(extent)))
+        assert exc.value.code == 2, why
+
+    def test_latitude_error_names_the_other_flag_s_ordering(self, caplog):
+        with caplog.at_level("ERROR"), pytest.raises(SystemExit):
+            resolve_extent(SimpleNamespace(extent=[-135.0, 21.0, -160.0, 53.0]))
+        assert "--dst-bounds" in caplog.text
+        assert "west south east north" in caplog.text
+
+    def test_the_undetectable_swap_is_documented_as_accepted(self):
+        """The case that actually bit: both readings are valid boxes.
+
+        `-135 21 -60 53` is a well-formed extent whichever convention
+        you read it in, so no validation can reject it. Pinned so the
+        limitation is explicit rather than an assumed-covered gap — the
+        mitigation for this one is the help text, not a check.
+        """
+        assert resolve_extent(SimpleNamespace(extent=[-135.0, 21.0, -60.0, 53.0])) == [
+            -135.0,
+            21.0,
+            -60.0,
+            53.0,
+        ]


### PR DESCRIPTION
Mirrored from **zyra-project/zyra** PR #288

Source: https://github.com/zyra-project/zyra/pull/288

> This PR is maintained by an automated relay. Changes should be made in the original downstream PR.