### PR TITLE
North is up again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zyra"
-version = "0.1.51"
+version = "0.1.52"
 description = "A tool to ingest data from various sources and formats, create imagery or video based on that data, and send the results to various locations for dissemination."
 authors = ["Eric Hackathorn <eric.j.hackathorn@noaa.gov>"]
 include = [

--- a/src/zyra/visualization/basemap.py
+++ b/src/zyra/visualization/basemap.py
@@ -16,6 +16,7 @@ def add_basemap_cartopy(
     extent: Optional[Iterable[float]] = None,
     *,
     image_path: Optional[str] = None,
+    image_extent: Optional[Iterable[float]] = None,
     features: Optional[Iterable[str]] = None,
     alpha: float = 1.0,
 ):
@@ -26,9 +27,20 @@ def add_basemap_cartopy(
     ax : cartopy.mpl.geoaxes.GeoAxesSubplot
         Target axes with a geographic projection (PlateCarree recommended).
     extent : iterable of float, optional
-        [west, east, south, north] in PlateCarree coordinates.
+        The **viewport**: [west, east, south, north] in PlateCarree
+        coordinates, passed to ``ax.set_extent``.
     image_path : str, optional
         Path to a background image to draw via ``imshow``.
+    image_extent : iterable of float, optional
+        The geographic extent **the image itself covers**, defaulting to
+        the whole globe — which is what every basemap shipped in
+        ``zyra.assets.images`` is (equirectangular, 2:1).
+
+        This is deliberately not ``extent``. Reusing the viewport here
+        stretched a global image into whatever region was being viewed,
+        so a North America viewport rendered the entire world squashed
+        into that box (#284). Cartopy crops the image to the viewport on
+        its own once the image is placed at its true extent.
     features : iterable of str, optional
         Feature names to add: any of {"coastline", "borders", "gridlines"}.
     alpha : float, default=1.0
@@ -51,13 +63,24 @@ def add_basemap_cartopy(
             ax.imshow(
                 img,
                 origin="upper",
-                extent=extent or [-180, 180, -90, 90],
+                extent=image_extent or [-180, 180, -90, 90],
                 transform=ccrs.PlateCarree(),
                 alpha=alpha,
             )
-        except Exception:
-            # Swallow image read failures; caller may still draw data
-            pass
+        except Exception as exc:
+            # Carrying on is right — the caller may still draw data over
+            # a blank background — but doing it silently is not. An
+            # unreadable asset (a Git LFS pointer left unfetched, say)
+            # otherwise renders as a plain white figure with no clue
+            # why, which reads as a bug in the data path.
+            import logging
+
+            logging.warning(
+                "basemap %s could not be drawn (%s: %s); continuing without it",
+                image_path,
+                type(exc).__name__,
+                exc,
+            )
 
     if features:
         for feat in features:

--- a/src/zyra/visualization/cli_register.py
+++ b/src/zyra/visualization/cli_register.py
@@ -52,7 +52,7 @@ def register_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: -180 180 -90 90)",
+        help="west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     p_hm.add_argument(
         "--output",
@@ -218,7 +218,7 @@ def register_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: -180 180 -90 90)",
+        help="west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     # Not required=True: --inputs/--output-dir is the documented batch
     # mode (see this flag's own help), and an argparse-level requirement
@@ -350,7 +350,7 @@ def register_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: -180 180 -90 90)",
+        help="west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     p_vec.add_argument("--width", type=int, default=1024)
     p_vec.add_argument("--height", type=int, default=512)
@@ -409,7 +409,7 @@ def register_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: -180 180 -90 90)",
+        help="west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     p_anim.add_argument("--width", type=int, default=1024)
     p_anim.add_argument("--height", type=int, default=512)
@@ -528,7 +528,7 @@ def register_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: -180 180 -90 90)",
+        help="west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     p_int.add_argument("--width", type=int, default=1024)
     p_int.add_argument("--height", type=int, default=512)

--- a/src/zyra/visualization/cli_sos.py
+++ b/src/zyra/visualization/cli_sos.py
@@ -202,7 +202,7 @@ def register_sos_cli(subparsers: Any) -> None:
         type=float,
         action="extend",
         default=None,
-        help="west east south north (default: global -180 180 -90 90)",
+        help="west east south north (default: global -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
     )
     p_sos.add_argument("--width", type=int, default=4096, help="Output width (px)")
     p_sos.add_argument("--height", type=int, default=2048, help="Output height (px)")

--- a/src/zyra/visualization/cli_utils.py
+++ b/src/zyra/visualization/cli_utils.py
@@ -18,6 +18,16 @@ def load_geotiff_array(input_path: str, *, band: int = 1):
     NaN renders transparent in the raster visualizers, so warp fill and
     masked regions disappear instead of plotting as a solid value.
 
+    The returned array is **south-up** — row 0 is the southernmost row.
+    That is the convention every raster visualizer here already assumes:
+    ``heatmap`` draws with ``origin="lower"`` and ``contour`` builds its
+    y coordinates as ``linspace(south, north)``. GeoTIFFs are
+    conventionally north-up instead, so returning one as read renders it
+    mirrored about the equator (see #281 — the global smoke frames put
+    northern-hemisphere plumes over the Southern Ocean). The flip is
+    keyed off the transform rather than assumed, so a genuinely south-up
+    GeoTIFF is left alone.
+
     Parameters
     ----------
     input_path : str
@@ -46,6 +56,13 @@ def load_geotiff_array(input_path: str, *, band: int = 1):
             )
         arr = ds.read(band).astype("float32")
         nodata = ds.nodata
+        # A negative y step means row 0 is the northernmost row; the
+        # visualizers want row 0 southernmost. `.copy()` because the
+        # reversed view is not contiguous and the nodata pass below
+        # writes in place.
+        north_up = ds.transform.e < 0
+    if north_up:
+        arr = arr[::-1, :].copy()
     if nodata is not None and not np.isnan(nodata):
         arr[arr == np.float32(nodata)] = np.nan
     return arr

--- a/src/zyra/visualization/cli_utils.py
+++ b/src/zyra/visualization/cli_utils.py
@@ -56,15 +56,17 @@ def load_geotiff_array(input_path: str, *, band: int = 1):
             )
         arr = ds.read(band).astype("float32")
         nodata = ds.nodata
-        # A negative y step means row 0 is the northernmost row; the
-        # visualizers want row 0 southernmost. `.copy()` because the
-        # reversed view is not contiguous and the nodata pass below
-        # writes in place.
+        # A negative y step means row 0 is the northernmost row.
         north_up = ds.transform.e < 0
-    if north_up:
-        arr = arr[::-1, :].copy()
+    # Map nodata first, while `arr` is still the contiguous buffer this
+    # function owns, so the in-place write stays cheap.
     if nodata is not None and not np.isnan(nodata):
         arr[arr == np.float32(nodata)] = np.nan
+    # Then reverse to south-up. A reversed slice is a view, so this
+    # costs no second allocation; doing it before the write above would
+    # have forced a copy of the whole raster.
+    if north_up:
+        arr = arr[::-1, :]
     return arr
 
 

--- a/src/zyra/visualization/cli_utils.py
+++ b/src/zyra/visualization/cli_utils.py
@@ -324,9 +324,9 @@ def resolve_extent(ns) -> list[float]:
     (``styles.DEFAULT_EXTENT``) when unset.
 
     Exits with code 2 (message on stderr via logging) on a wrong-length
-    value. The numeric exit code keeps the failure a clean exit-status
-    signal rather than relying on the Domain API executor's message-string
-    handling.
+    value, or on one whose bounds are inverted — see below. The numeric
+    exit code keeps the failure a clean exit-status signal rather than
+    relying on the Domain API executor's message-string handling.
     """
     extent = getattr(ns, "extent", None)
     if extent is None:
@@ -336,7 +336,51 @@ def resolve_extent(ns) -> list[float]:
 
         logging.error("--extent takes exactly 4 values: west east south north")
         raise SystemExit(2)
-    return [float(v) for v in extent]
+    west, east, south, north = (float(v) for v in extent)
+    # `--extent` is [west, east, south, north] (matplotlib's `imshow`
+    # order) while `process reproject --dst-bounds` is [west, south,
+    # east, north] (the GDAL/rasterio bbox order). A regional pipeline
+    # writes both, adjacent, so passing one in the other's order is easy
+    # and silent — four plausible numbers rendering a valid picture of
+    # the wrong part of the world (#287).
+    #
+    # It cannot be detected in general: both orderings can describe a
+    # perfectly well-formed box, and `-135 21 -60 53` is exactly that
+    # either way round. What *is* checkable is that the two values in
+    # the latitude slots really are latitudes — a longitude landing
+    # there is the common tell, since longitudes routinely exceed ±90
+    # while latitudes never do.
+    for name, value in (("south", south), ("north", north)):
+        if not -90.0 <= value <= 90.0:
+            import logging
+
+            logging.error(
+                "--extent takes west east south north; %s=%g is not a valid "
+                "latitude. Note that `process reproject --dst-bounds` uses a "
+                "different order (west south east north) — did you mean "
+                "--extent %g %g %g %g?",
+                name,
+                value,
+                west,
+                south,
+                east,
+                north,
+            )
+            raise SystemExit(2)
+    # Latitudes do not wrap, so an inverted pair is always an error.
+    # Longitudes deliberately are not checked: west > east is how a
+    # dateline-crossing extent is written.
+    if north <= south:
+        import logging
+
+        logging.error(
+            "--extent takes west east south north; south=%g is not below "
+            "north=%g, so the extent is empty",
+            south,
+            north,
+        )
+        raise SystemExit(2)
+    return [west, east, south, north]
 
 
 def features_from_ns(ns) -> list[str] | None:

--- a/src/zyra/wizard/zyra_capabilities.json
+++ b/src/zyra/wizard/zyra_capabilities.json
@@ -3202,7 +3202,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -3462,7 +3462,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -3797,7 +3797,7 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -4039,7 +4039,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -4409,7 +4409,7 @@
         "default": 3
       },
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -4582,7 +4582,7 @@
       },
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
-        "help": "west east south north (default: global -180 180 -90 90)",
+        "help": "west east south north (default: global -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -4708,7 +4708,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -4935,7 +4935,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -5237,7 +5237,7 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -5452,7 +5452,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -5787,7 +5787,7 @@
         "default": 3
       },
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -5916,7 +5916,7 @@
       },
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
-        "help": "west east south north (default: global -180 180 -90 90)",
+        "help": "west east south north (default: global -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {

--- a/src/zyra/wizard/zyra_capabilities/visualize.json
+++ b/src/zyra/wizard/zyra_capabilities/visualize.json
@@ -110,7 +110,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -426,7 +426,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -621,7 +621,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -867,7 +867,7 @@
         "default": 3
       },
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -996,7 +996,7 @@
       },
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
-        "help": "west east south north (default: global -180 180 -90 90)",
+        "help": "west east south north (default: global -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -1229,7 +1229,7 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -1444,7 +1444,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -1795,7 +1795,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -2006,7 +2006,7 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--output": {
@@ -2285,7 +2285,7 @@
         "default": 3
       },
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -2458,7 +2458,7 @@
       },
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
-        "help": "west east south north (default: global -180 180 -90 90)",
+        "help": "west east south north (default: global -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {
@@ -2708,7 +2708,7 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north (default: -180 180 -90 90)",
+        "help": "west east south north (default: -180 180 -90 90) (note: `process reproject --dst-bounds` uses west south east north)",
         "type": "float"
       },
       "--width": {

--- a/tests/notebook/conftest.py
+++ b/tests/notebook/conftest.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Keep notebook-session tests out of the working tree.
+
+``NotebookRegistry`` writes ``notebook_capabilities_overlay.json`` and a
+``provenance.sqlite`` under its workdir, and ``_resolve_workdir`` falls
+back to :func:`Path.cwd` when neither an explicit ``workdir`` nor
+``ZYRA_NOTEBOOK_DIR`` is set. A test that builds a session without a
+workdir therefore drops both files into the repository root — so running
+the suite left the tree dirty.
+
+Pinning the env var per test fixes the whole package rather than one call
+site, and keeps a future test from reintroducing it. Nothing here asserts
+the CWD fallback itself, so overriding it costs no coverage.
+
+The two ``setdefault`` calls in ``NotebookRegistry.__init__`` are why the
+env vars are cleared as well: ``setdefault`` will not overwrite, so the
+first session in a process would otherwise pin every later one to its own
+temporary directory.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_notebook_workdir(tmp_path, monkeypatch):
+    monkeypatch.setenv("ZYRA_NOTEBOOK_DIR", str(tmp_path))
+    monkeypatch.delenv("ZYRA_NOTEBOOK_PROVENANCE", raising=False)
+    monkeypatch.delenv("ZYRA_NOTEBOOK_OVERLAY", raising=False)

--- a/tests/notebook/conftest.py
+++ b/tests/notebook/conftest.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Keep notebook-session tests out of the working tree.
 
-``NotebookRegistry`` writes ``notebook_capabilities_overlay.json`` and a
+``Session`` (`zyra.notebook.registry`) writes ``notebook_capabilities_overlay.json`` and a
 ``provenance.sqlite`` under its workdir, and ``_resolve_workdir`` falls
 back to :func:`Path.cwd` when neither an explicit ``workdir`` nor
 ``ZYRA_NOTEBOOK_DIR`` is set. A test that builds a session without a
@@ -12,7 +12,7 @@ Pinning the env var per test fixes the whole package rather than one call
 site, and keeps a future test from reintroducing it. Nothing here asserts
 the CWD fallback itself, so overriding it costs no coverage.
 
-The two ``setdefault`` calls in ``NotebookRegistry.__init__`` are why the
+The two ``setdefault`` calls in ``Session.__init__`` are why the
 env vars are cleared as well: ``setdefault`` will not overwrite, so the
 first session in a process would otherwise pin every later one to its own
 temporary directory.

--- a/tests/visualization/test_basemap_extent.py
+++ b/tests/visualization/test_basemap_extent.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Basemap image placement vs. the viewport (#284).
+
+``add_basemap_cartopy`` took one ``extent`` and used it for two
+different things: the viewport handed to ``ax.set_extent``, and the
+geographic extent the background image covers. Those coincide only when
+the view is global, so a regional ``--extent`` stretched the whole world
+into that box — a North America view rendering Eurasia inside it.
+
+The fixtures here build their own basemap rather than using
+``zyra.assets.images``: those are Git LFS-tracked, and a checkout
+without the objects fetched has pointer files that ``imread`` cannot
+parse, which would make these tests pass for the wrong reason.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("cartopy")
+pytest.importorskip("matplotlib")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+import cartopy.crs as ccrs  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib import image as mpimg  # noqa: E402
+
+from zyra.visualization.basemap import add_basemap_cartopy  # noqa: E402
+
+# A North America viewport, in [west, east, south, north].
+VIEWPORT = [-135.0, -60.0, 21.0, 53.0]
+
+
+def _write_global_basemap(path):
+    """A black 1°/px world with a white block over Australia.
+
+    The block sits far outside `VIEWPORT`, which is what makes the
+    assertion a clean boolean: placed correctly the block is off-screen,
+    while squashing the globe into the viewport drags it into frame.
+    """
+    img = np.zeros((180, 360, 3), dtype="uint8")
+    # lon 100..140E, lat 20..60S -> rows/cols in a north-up 1°/px grid.
+    img[110:150, 280:320] = 255
+    mpimg.imsave(str(path), img)
+
+
+def _render(tmp_path, basemap):
+    fig = plt.figure(figsize=(6, 3), dpi=50)
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    add_basemap_cartopy(ax, VIEWPORT, image_path=str(basemap))
+    out = tmp_path / "render.png"
+    fig.savefig(out, bbox_inches="tight", pad_inches=0)
+    plt.close(fig)
+    return np.asarray(mpimg.imread(str(out)))[..., :3]
+
+
+def test_regional_viewport_does_not_drag_in_the_whole_globe(tmp_path):
+    basemap = tmp_path / "world.png"
+    _write_global_basemap(basemap)
+
+    rendered = _render(tmp_path, basemap)
+
+    # Rendered floats in 0..1; the marker is pure white.
+    bright = (rendered > 0.9).all(axis=-1).mean()
+    assert bright == 0.0, (
+        "the Australia marker is outside the North America viewport, so it "
+        f"must not appear; {bright:.1%} of the render is white, which means "
+        "the global image was squashed into the viewport"
+    )
+
+
+def test_explicit_image_extent_is_honored(tmp_path):
+    """A caller may declare that the image covers only the viewport.
+
+    This is the case the old code got right by accident, and it has to
+    keep working — an image whose extent genuinely is the viewport
+    should fill the frame.
+    """
+    basemap = tmp_path / "region.png"
+    img = np.full((32, 75, 3), 255, dtype="uint8")
+    mpimg.imsave(str(basemap), img)
+
+    fig = plt.figure(figsize=(6, 3), dpi=50)
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    add_basemap_cartopy(ax, VIEWPORT, image_path=str(basemap), image_extent=VIEWPORT)
+    out = tmp_path / "region_render.png"
+    fig.savefig(out, bbox_inches="tight", pad_inches=0)
+    plt.close(fig)
+
+    rendered = np.asarray(mpimg.imread(str(out)))[..., :3]
+    bright = (rendered > 0.9).all(axis=-1).mean()
+    assert (
+        bright > 0.9
+    ), f"image declared at the viewport should fill it, got {bright:.1%}"
+
+
+def test_unreadable_basemap_warns_instead_of_failing_silently(tmp_path, caplog):
+    """An asset that will not parse must say so.
+
+    Git LFS pointer files are the motivating case: `imread` raises, the
+    render comes out blank, and before this the exception was swallowed
+    with no message at all.
+    """
+    bad = tmp_path / "pointer.jpg"
+    bad.write_text("version https://git-lfs.github.com/spec/v1\noid sha256:deadbeef\n")
+
+    fig = plt.figure(figsize=(4, 2), dpi=50)
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    with caplog.at_level("WARNING"):
+        add_basemap_cartopy(ax, VIEWPORT, image_path=str(bad))
+    plt.close(fig)
+
+    assert "pointer.jpg" in caplog.text
+    assert "could not be drawn" in caplog.text

--- a/tests/visualization/test_extent_flags.py
+++ b/tests/visualization/test_extent_flags.py
@@ -88,3 +88,64 @@ def test_api_argv_round_trips_extent():
     assert argv[:2] == ["visualize", "heatmap"]
     ns = _parser().parse_args(argv[1:])
     assert ns.extent == [-120.0, -60.0, 20.0, 55.0]
+
+
+class TestExtentValueValidation:
+    """`--extent` value checks (#287).
+
+    `--extent` is [west, east, south, north]; `process reproject
+    --dst-bounds` is [west, south, east, north]. A regional pipeline
+    writes both, adjacent, and passing one in the other's order renders
+    a valid picture of the wrong part of the world with no error.
+
+    The swap is not detectable in general — both orderings can describe
+    a well-formed box — so these check the part that is: the two values
+    in the latitude slots have to be latitudes.
+    """
+
+    @pytest.mark.parametrize(
+        ("extent", "why"),
+        [
+            ([-135.0, -60.0, 21.0, 53.0], "a regional box"),
+            ([-180.0, 180.0, -90.0, 90.0], "the global default"),
+            # west > east is how a dateline-crossing extent is written,
+            # so longitudes are deliberately not order-checked.
+            ([170.0, -170.0, -10.0, 10.0], "crossing the dateline"),
+        ],
+    )
+    def test_valid_extents_are_accepted(self, extent, why):
+        assert resolve_extent(SimpleNamespace(extent=list(extent))) == list(extent), why
+
+    @pytest.mark.parametrize(
+        ("extent", "why"),
+        [
+            ([-135.0, 21.0, -160.0, 53.0], "a longitude in the south slot"),
+            ([0.0, 10.0, -95.0, 95.0], "latitudes beyond the poles"),
+            ([-135.0, -60.0, 53.0, 21.0], "south above north — an empty box"),
+        ],
+    )
+    def test_invalid_extents_exit_2(self, extent, why):
+        with pytest.raises(SystemExit) as exc:
+            resolve_extent(SimpleNamespace(extent=list(extent)))
+        assert exc.value.code == 2, why
+
+    def test_latitude_error_names_the_other_flag_s_ordering(self, caplog):
+        with caplog.at_level("ERROR"), pytest.raises(SystemExit):
+            resolve_extent(SimpleNamespace(extent=[-135.0, 21.0, -160.0, 53.0]))
+        assert "--dst-bounds" in caplog.text
+        assert "west south east north" in caplog.text
+
+    def test_the_undetectable_swap_is_documented_as_accepted(self):
+        """The case that actually bit: both readings are valid boxes.
+
+        `-135 21 -60 53` is a well-formed extent whichever convention
+        you read it in, so no validation can reject it. Pinned so the
+        limitation is explicit rather than an assumed-covered gap — the
+        mitigation for this one is the help text, not a check.
+        """
+        assert resolve_extent(SimpleNamespace(extent=[-135.0, 21.0, -60.0, 53.0])) == [
+            -135.0,
+            21.0,
+            -60.0,
+            53.0,
+        ]

--- a/tests/visualization/test_geotiff_input.py
+++ b/tests/visualization/test_geotiff_input.py
@@ -51,7 +51,11 @@ def test_load_geotiff_band1_default(tmp_path):
     _write_tif(tif, data)
     out = load_geotiff_array(tif)
     assert out.shape == (3, 4)
-    assert float(out[2, 3]) == 11.0
+    # `_write_tif` writes north-up (row 0 north), and the loader returns
+    # south-up, so the source's last row comes back first. Indexing the
+    # raw read order here is what let #281 hide: it agrees with a
+    # mirrored array.
+    assert float(out[0, 3]) == 11.0
 
 
 def test_load_geotiff_nodata_maps_to_nan(tmp_path):
@@ -60,7 +64,8 @@ def test_load_geotiff_nodata_maps_to_nan(tmp_path):
     data[0, 0] = -999.0
     _write_tif(tif, data, nodata=-999.0)
     out = load_geotiff_array(tif)
-    assert np.isnan(out[0, 0])
+    # Source row 0 is northernmost; it comes back last (see #281).
+    assert np.isnan(out[-1, 0])
     assert float(out[1, 1]) == 7.0
     # Only the nodata cell is masked.
     assert int(np.isnan(out).sum()) == 1
@@ -286,3 +291,56 @@ def test_heatmap_without_any_input_exits_2():
     assert proc.returncode == 2
     assert "--input is required" in proc.stderr
     assert "Traceback" not in proc.stderr
+
+
+def test_north_up_geotiff_loads_south_up(tmp_path):
+    """A north-up GeoTIFF comes back row-0-southernmost (#281).
+
+    `heatmap` draws with ``origin="lower"`` and `contour` builds its y
+    coordinates as ``linspace(south, north)``, so both read row 0 as the
+    southernmost. Returning a north-up raster as read mirrors the data
+    about the equator — which is what put northern-hemisphere smoke
+    plumes over the Southern Ocean in the published global frames.
+    """
+    tif = str(tmp_path / "north_up.tif")
+    data = np.zeros((8, 4), dtype="float32")
+    data[:4, :] = 1.0  # north half hot, in north-up row order
+    _write_tif(tif, data)
+
+    out = load_geotiff_array(tif)
+
+    assert out[:4].max() == 0.0, "southern half should be cold"
+    assert out[4:].min() == 1.0, "northern half should be hot"
+
+
+def test_south_up_geotiff_is_left_alone(tmp_path):
+    """A genuinely south-up GeoTIFF must not be flipped.
+
+    The fix keys off the transform's y step rather than assuming every
+    GeoTIFF is north-up, so this is the case a blanket ``[::-1]`` would
+    silently break.
+    """
+    from rasterio.transform import Affine
+
+    tif = str(tmp_path / "south_up.tif")
+    data = np.zeros((8, 4), dtype="float32")
+    data[4:, :] = 1.0  # north half hot, already in south-up row order
+    # Positive y step: row 0 is the southernmost row.
+    with rasterio.open(
+        tif,
+        "w",
+        driver="GTiff",
+        width=4,
+        height=8,
+        count=1,
+        dtype="float32",
+        crs=CRS.from_epsg(4326),
+        transform=Affine(90.0, 0.0, -180.0, 0.0, 22.5, -90.0),
+    ) as dst:
+        dst.write(data, 1)
+
+    out = load_geotiff_array(tif)
+
+    assert out[:4].max() == 0.0
+    assert out[4:].min() == 1.0
+    np.testing.assert_array_equal(out, data)


### PR DESCRIPTION
This release fixes two ways the raster visualizers put data in the wrong place on the map. Both had been shipping wrong pictures for a while, and neither looked broken — which is the whole problem with a geographic error: the output is a perfectly good image of somewhere else.

The first is the serious one. `visualize heatmap` and `visualize contour` rendered GeoTIFF input **mirrored north–south**. A GeoTIFF is conventionally north-up — row 0 is the northernmost — but both renderers draw with `origin="lower"`, which declares row 0 to be the southernmost. Any pipeline shaped `process convert-format geotiff` → `process reproject` → `visualize heatmap` has been publishing frames with the data flipped against its own basemap. It surfaced when someone asked why a global smoke product had plumes sitting over open ocean: they were northern-hemisphere fires, reflected into the Southern Ocean.

**Visualization**

*   GeoTIFF input is loaded south-up ([#338](https://github.com/NOAA-GSL/zyra/pull/338)), matching the convention every raster visualizer already assumes. `load_geotiff_array` is shared, so this corrects `heatmap`, `contour` and `visualize sos` together. The flip is keyed off the transform's y step rather than assumed, so a genuinely south-up GeoTIFF is left alone. `--flipud` was not a workaround: it is never wired from the parser, and it flips the array *and* the origin, so the two changes cancel and both settings were wrong for north-up input.
*   The basemap image is drawn at its own geographic extent rather than the viewport ([#341](https://github.com/NOAA-GSL/zyra/pull/341)). `add_basemap_cartopy` used one `extent` for two different things — the viewport handed to `set_extent`, and the area the background image covers. Those coincide only when the view is global, so a regional `--extent` stretched the entire world into that box: a North America viewport rendering Eurasia inside it. Every basemap shipped in `zyra.assets.images` is global equirectangular, so that is now the default, with a new `image_extent` argument for a caller who genuinely has a regional image.
*   A basemap that cannot be read now logs a warning instead of vanishing ([#341](https://github.com/NOAA-GSL/zyra/pull/341)). The load was wrapped in a bare `except: pass`, so an unreadable asset — a Git LFS pointer left unfetched is the easy way to get one — produced a plain white background with no message at all, which reads as a broken data path rather than a missing file. The fallback behaviour is unchanged: the render continues and the caller may still draw data over it.

**CLI**

*   `--extent` validates its latitudes ([#344](https://github.com/NOAA-GSL/zyra/pull/344)). `visualize --extent` is `[west, east, south, north]`; `process reproject --dst-bounds` is `[west, south, east, north]`. A regional pipeline writes both, adjacent, and passing one in the other's order renders a valid picture of the wrong part of the world. Values in the two latitude slots must now be latitudes, and `south` must be below `north`; either failure exits 2 with a message naming the other flag's ordering. Longitudes are deliberately not order-checked, because `west > east` is how a dateline-crossing extent is written.
*   The `--extent` help text on all six commands now names the `--dst-bounds` ordering. This is doing more work than the validation: the confusion is not detectable in general — `-135 21 -60 53` is a well-formed box under either convention — so for the case that actually bites, documentation is the only mitigation.

**Testing**

*   Notebook-session tests no longer write into the working tree ([#339](https://github.com/NOAA-GSL/zyra/pull/339)). `Session` falls back to `Path.cwd()` when no workdir is set, so running the suite dropped `notebook_capabilities_overlay.json` and `provenance.sqlite` into the repository root. Pinned per-test in a package `conftest.py` so a future test cannot reintroduce it.

**Compatibility**

Two behaviour changes worth checking before upgrading.

*   **Rendered output changes for GeoTIFF input, and that is the point.** Any dataset whose frames were rendered from GeoTIFF is mirrored today and will render correctly after upgrading — those frames need republishing, since the fix corrects the renderer, not the images already produced. If a pipeline compensated by pre-flipping its data, that compensation must be removed.
*   **`--extent` can now reject values it previously accepted.** A latitude outside ±90, or `south` at or above `north`, exits 2 rather than rendering something meaningless. A regional basemap paired with a matching `--extent` also relied on the old viewport coupling; use `image_extent` to declare the image's own extent.

No API changes. Global renders are unaffected by the basemap change — verified with markers at known coordinates, which land identically before and after.