### PR TITLE
Codex Relay: zyra-project/zyra PR #291 — Refuse --width/--height/--dpi in data-encoded mode

### DIFF
--- a/src/zyra/api/schemas/domain_args.py
+++ b/src/zyra/api/schemas/domain_args.py
@@ -139,6 +139,25 @@ class VisualizeHeatmapArgs(BaseModel):
     def _data_encoded_needs_range(self):  # type: ignore[override]
         if self.data_encoded and (self.vmin is None or self.vmax is None):
             raise ValueError("data_encoded requires both vmin and vmax")
+        # width/height/dpi size a matplotlib figure. A data-encoded
+        # frame is written at the source grid and never builds one, so
+        # accepting them would promise a size that is never applied.
+        # These fields default to None, so unlike the CLI this can tell
+        # an omitted value from one supplied at the parser default, and
+        # so rejects any value at all — the two surfaces differ only in
+        # that this one is the stricter.
+        if self.data_encoded:
+            supplied = [
+                name
+                for name in ("width", "height", "dpi")
+                if getattr(self, name, None) is not None
+            ]
+            if supplied:
+                raise ValueError(
+                    f"data_encoded does not support {'/'.join(supplied)}: the frame is "
+                    "written at the source grid, and resizing it would average values "
+                    "that were never measured. Regrid upstream instead."
+                )
         return self
 
     @field_validator("extent")

--- a/src/zyra/visualization/cli_heatmap.py
+++ b/src/zyra/visualization/cli_heatmap.py
@@ -169,6 +169,51 @@ def _handle_heatmap_impl(ns) -> int:
     return 0
 
 
+def _reject_figure_canvas_args(ns) -> None:
+    """Refuse --width/--height/--dpi in data-encoded mode.
+
+    These size a matplotlib figure. A data-encoded frame is written at
+    the source grid and never builds one, so honouring them would mean
+    resampling values nobody measured — which is the failure this whole
+    output exists to avoid. Accepting them and quietly doing something
+    else is worse than refusing: the caller reads the flag they passed,
+    sees a file, and has no way to learn the size never applied.
+
+    Refusing rather than warning matches how this module already treats
+    a meaningless combination — --output-names without --inputs, and
+    --vmin/--vmax against a classified palette both exit 2. Regridding
+    belongs upstream, where it is a deliberate and inspectable step.
+
+    Only non-default values are refused. argparse cannot distinguish an
+    omitted flag from one passed at its default, so `--width 1024` is
+    indistinguishable from silence here and slips through. The API
+    model has no such blind spot — its fields default to None — and
+    rejects any value at all, so the two surfaces differ only in that
+    the API is the stricter one.
+    """
+    from zyra.visualization.cli_register import (
+        HEATMAP_DEFAULT_DPI,
+        HEATMAP_DEFAULT_HEIGHT,
+        HEATMAP_DEFAULT_WIDTH,
+    )
+
+    supplied = [
+        name
+        for name, default in (
+            ("--width", HEATMAP_DEFAULT_WIDTH),
+            ("--height", HEATMAP_DEFAULT_HEIGHT),
+            ("--dpi", HEATMAP_DEFAULT_DPI),
+        )
+        if getattr(ns, name.lstrip("-"), default) not in (None, default)
+    ]
+    if supplied:
+        raise ValueError(
+            f"{'/'.join(supplied)} cannot be used with --data-encoded: the frame is "
+            "written at the source grid, and resizing it would average values that "
+            "were never measured. Regrid upstream instead."
+        )
+
+
 def _handle_data_encoded(ns) -> int:
     """Write value-exact grayscale frames plus the palette sidecar.
 
@@ -188,6 +233,7 @@ def _handle_data_encoded(ns) -> int:
     vmax = getattr(ns, "vmax", None)
     if vmin is None or vmax is None:
         raise ValueError("--vmin and --vmax are required with --data-encoded")
+    _reject_figure_canvas_args(ns)
 
     palette = None
     cmap_file = getattr(ns, "cmap_file", None)

--- a/src/zyra/visualization/cli_register.py
+++ b/src/zyra/visualization/cli_register.py
@@ -14,6 +14,14 @@ from .cli_sos import register_sos_cli
 from .cli_timeseries import handle_timeseries
 from .cli_vector import handle_vector
 
+# Figure-canvas defaults for `visualize heatmap`. Named because the
+# data-encoded path has to tell "the caller asked for this size" from
+# "argparse supplied it", and comparing against a literal here and a
+# literal there is how those two drift apart.
+HEATMAP_DEFAULT_WIDTH = 1024
+HEATMAP_DEFAULT_HEIGHT = 512
+HEATMAP_DEFAULT_DPI = 96
+
 
 def register_cli(subparsers: Any) -> None:
     """Register visualization subcommands using lightweight CLI modules.
@@ -84,9 +92,9 @@ def register_cli(subparsers: Any) -> None:
             "(default: the source stem + .png)"
         ),
     )
-    p_hm.add_argument("--width", type=int, default=1024)
-    p_hm.add_argument("--height", type=int, default=512)
-    p_hm.add_argument("--dpi", type=int, default=96)
+    p_hm.add_argument("--width", type=int, default=HEATMAP_DEFAULT_WIDTH)
+    p_hm.add_argument("--height", type=int, default=HEATMAP_DEFAULT_HEIGHT)
+    p_hm.add_argument("--dpi", type=int, default=HEATMAP_DEFAULT_DPI)
     hm_cmap = p_hm.add_mutually_exclusive_group()
     hm_cmap.add_argument("--cmap", default="YlOrBr")
     hm_cmap.add_argument(

--- a/src/zyra/visualization/luma_writer.py
+++ b/src/zyra/visualization/luma_writer.py
@@ -153,7 +153,11 @@ def build_color_scale(
         )
 
     ts = np.linspace(0.0, 1.0, SIDECAR_STOPS)
-    rgba = _sample_palette(palette_spec, ts, vmin=float(vmin), vmax=span + float(vmin))
+    # `span` is only the finite/distinct guard above; pass the caller's
+    # own bounds through. Reconstructing vmax as `span + vmin` is equal
+    # for every physically plausible range, but it says "some derived
+    # quantity" where the argument is simply vmax.
+    rgba = _sample_palette(palette_spec, ts, vmin=float(vmin), vmax=float(vmax))
 
     scale: dict[str, Any] = {
         "stops": [

--- a/tests/visualization/test_luma_writer.py
+++ b/tests/visualization/test_luma_writer.py
@@ -17,6 +17,7 @@ import json
 
 import numpy as np
 import pytest
+from pydantic import ValidationError
 
 from zyra.visualization.luma_writer import (
     SIDECAR_STOPS,
@@ -343,6 +344,90 @@ class TestDataEncodedCli:
         # (which would put equal values on all three channels).
         assert scale["stops"][SIDECAR_STOPS // 4]["rgba"][:3] == [0, 0, 255]
         assert scale["stops"][3 * SIDECAR_STOPS // 4]["rgba"][:3] == [255, 0, 0]
+
+    @pytest.mark.parametrize(
+        ("flag", "value"), [("width", 2048), ("height", 1024), ("dpi", 300)]
+    )
+    def test_handler_exits_2_on_a_figure_canvas_flag(self, tmp_path, flag, value):
+        # These size a matplotlib figure. Honouring them here would
+        # resample the grid; accepting and ignoring them would promise a
+        # size that never applied. Refuse, matching how --output-names
+        # and a classified palette + --vmin/--vmax are already treated.
+        from zyra.visualization.cli_heatmap import handle_heatmap
+
+        src = tmp_path / "in.npy"
+        np.save(src, np.zeros((2, 2)))
+        ns = self._ns(
+            input=str(src),
+            output=str(tmp_path / "o.png"),
+            data_encoded=True,
+            vmin=0,
+            vmax=100,
+            **{flag: value},
+        )
+        assert handle_heatmap(ns) == 2
+
+    def test_handler_tolerates_a_figure_canvas_flag_at_its_default(self, tmp_path):
+        # argparse cannot tell an omitted flag from one passed at its
+        # own default, so this slips through. Pinned so the limitation
+        # is a known one rather than a surprise; the API model has no
+        # such blind spot.
+        from zyra.visualization.cli_heatmap import handle_heatmap
+        from zyra.visualization.cli_register import HEATMAP_DEFAULT_WIDTH
+
+        src = tmp_path / "in.npy"
+        np.save(src, np.zeros((2, 2)))
+        ns = self._ns(
+            input=str(src),
+            output=str(tmp_path / "o.png"),
+            data_encoded=True,
+            vmin=0,
+            vmax=100,
+            width=HEATMAP_DEFAULT_WIDTH,
+        )
+        assert handle_heatmap(ns) == 0
+
+    def test_picture_path_still_accepts_the_canvas_flags(self, tmp_path):
+        # The refusal must be scoped to --data-encoded. A plain heatmap
+        # invocation carrying --width is the common case and unaffected.
+        ns = self._ns(input="a.tif", output="o.png", width=2048)
+        assert ns.width == 2048
+        assert getattr(ns, "data_encoded", False) is False
+
+    @pytest.mark.parametrize("field", ["width", "height", "dpi"])
+    def test_api_model_rejects_a_canvas_field_with_data_encoded(self, field):
+        from zyra.api.schemas.domain_args import VisualizeHeatmapArgs
+
+        with pytest.raises(ValidationError):
+            VisualizeHeatmapArgs(
+                input="a.tif",
+                output="o.png",
+                data_encoded=True,
+                vmin=0,
+                vmax=10,
+                **{field: 2048},
+            )
+
+    def test_api_model_rejects_even_the_cli_default_size(self):
+        # The model's fields default to None, so unlike the CLI it can
+        # tell "supplied 1024" from "not supplied" — and does.
+        from zyra.api.schemas.domain_args import VisualizeHeatmapArgs
+
+        with pytest.raises(ValidationError):
+            VisualizeHeatmapArgs(
+                input="a.tif",
+                output="o.png",
+                data_encoded=True,
+                vmin=0,
+                vmax=10,
+                width=1024,
+            )
+
+    def test_api_model_still_allows_a_size_without_data_encoded(self):
+        from zyra.api.schemas.domain_args import VisualizeHeatmapArgs
+
+        m = VisualizeHeatmapArgs(input="a.tif", output="o.png", width=2048, dpi=300)
+        assert m.width == 2048 and m.dpi == 300
 
     def test_handler_exits_2_without_a_range(self, tmp_path):
         from zyra.visualization.cli_heatmap import handle_heatmap


### PR DESCRIPTION
Mirrored from **zyra-project/zyra** PR #291

Source: https://github.com/zyra-project/zyra/pull/291

> This PR is maintained by an automated relay. Changes should be made in the original downstream PR.