### PR TITLE
Version 0.1.54: North is up on the other path too

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zyra"
-version = "0.1.53"
+version = "0.1.54"
 description = "A tool to ingest data from various sources and formats, create imagery or video based on that data, and send the results to various locations for dissemination."
 authors = ["Eric Hackathorn <eric.j.hackathorn@noaa.gov>"]
 include = [

--- a/scripts/wait_for_pypi.py
+++ b/scripts/wait_for_pypi.py
@@ -150,11 +150,25 @@ def is_fetchable(url: str, timeout: float = 10.0) -> bool:
 
 
 def is_version_available(package: str, version: str, timeout: float = 10.0) -> bool:
-    """Whether ``version`` is both listed *and* downloadable.
+    """Whether ``version`` is listed *and* every listed file is downloadable.
 
     Listing alone is what this used to check, and it is not enough: a
     green check followed immediately by a 404 inside a Docker build is
     exactly the failure this guard exists to prevent.
+
+    **Every** file, not the first one that answers. Requiring only one
+    would pick the wrong file as often as not: pip installs the wheel
+    normally, but a source build — a ``--no-binary`` install, or a
+    platform with no matching wheel — reaches for the sdist, so a green
+    check on whichever happened to respond first says nothing about the
+    file pip will actually download. All of them serving is also better
+    evidence of the thing actually being waited on, which is that the
+    release has propagated to the edge serving this build.
+
+    The two ways of being wrong are not symmetric. Waiting too long is
+    bounded by ``retries × delay`` and merely delays a release; going
+    green too early fails the image build, which is the bug this exists
+    to fix.
     """
     urls = file_urls_for_version(package, version, timeout=timeout)
     if not urls:

--- a/scripts/wait_for_pypi.py
+++ b/scripts/wait_for_pypi.py
@@ -32,10 +32,7 @@ def fetch_json(url: str, timeout: float = 10.0) -> dict[str, Any]:
     This validation mitigates SSRF risks when the URL is constructed from
     untrusted input in future refactors.
     """
-    parsed = urlparse(url)
-    if parsed.scheme != "https" or parsed.netloc.lower() != "pypi.org":
-        raise ValueError(f"Refusing to fetch non-PyPI URL: {url}")
-    with urllib.request.urlopen(url, timeout=timeout) as r:
+    with _urlopen(url, "pypi.org", timeout=timeout) as r:
         return json.load(r)
 
 
@@ -57,10 +54,52 @@ def _require_allowed_url(url: str, *hosts: str) -> None:
     Guards against SSRF if a URL ever reaches here from untrusted input.
     ``files.pythonhosted.org`` is allowed alongside ``pypi.org`` because
     the file check below has to follow the index's own links.
+
+    Compares ``hostname`` rather than ``netloc``: netloc carries the port
+    and any userinfo, so an explicit ``https://pypi.org:443/...`` — same
+    host, same default port — would be refused as a stranger. ``hostname``
+    normalises the port away, strips userinfo, and lowercases.
     """
+    allowed = tuple(h.lower() for h in hosts)
     parsed = urlparse(url)
-    if parsed.scheme != "https" or parsed.netloc.lower() not in hosts:
-        raise ValueError(f"Refusing to fetch non-PyPI URL: {url}")
+    if parsed.scheme != "https" or (parsed.hostname or "") not in allowed:
+        raise ValueError(
+            f"Refusing to fetch {url}: not HTTPS on {' or '.join(allowed)}"
+        )
+
+
+class _AllowlistRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Re-check the allowlist on each redirect hop.
+
+    urllib follows redirects by itself, so validating only the URL we ask
+    for checks the one hop that was never in doubt: a 302 pointing off the
+    allowlist would be followed, and the request issued, before anything
+    looked at it. Checking ``geturl()`` after ``urlopen`` returns is too
+    late for the same reason — by then it has been fetched. Refusing here
+    stops the hop before it goes out.
+    """
+
+    def __init__(self, hosts: tuple[str, ...]) -> None:
+        super().__init__()
+        self._hosts = hosts
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        _require_allowed_url(newurl, *self._hosts)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _urlopen(url_or_req, *hosts: str, timeout: float = 10.0):  # type: ignore[no-untyped-def]
+    """``urlopen`` with the allowlist enforced on the request *and* redirects.
+
+    The single seam every fetch in this module goes through, so the guard
+    cannot be bypassed by adding a call site that forgets it.
+    """
+    target = url_or_req if isinstance(url_or_req, str) else url_or_req.full_url
+    _require_allowed_url(target, *hosts)
+    opener = urllib.request.build_opener(
+        _AllowlistRedirectHandler(tuple(h.lower() for h in hosts))
+    )
+    return opener.open(url_or_req, timeout=timeout)
 
 
 def file_urls_for_version(
@@ -74,8 +113,7 @@ def file_urls_for_version(
     """
     normalized = pep503_normalize(package)
     simple_url = f"https://pypi.org/simple/{normalized}/"
-    _require_allowed_url(simple_url, "pypi.org")
-    with urllib.request.urlopen(simple_url, timeout=timeout) as r:
+    with _urlopen(simple_url, "pypi.org", timeout=timeout) as r:
         html = r.read().decode("utf-8", errors="replace")
 
     # Wheels escape the name with underscores (PEP 427); sdists use the
@@ -106,9 +144,8 @@ def is_fetchable(url: str, timeout: float = 10.0) -> bool:
     "downloadable" are separate facts, and only the second one is the
     condition a build actually needs.
     """
-    _require_allowed_url(url, FILES_HOST, "pypi.org")
     req = urllib.request.Request(url, headers={"Range": "bytes=0-0"})
-    with urllib.request.urlopen(req, timeout=timeout) as r:
+    with _urlopen(req, FILES_HOST, "pypi.org", timeout=timeout) as r:
         return r.status in (200, 206)
 
 

--- a/scripts/wait_for_pypi.py
+++ b/scripts/wait_for_pypi.py
@@ -15,6 +15,7 @@ Exits with code 0 when the version is available, 1 on timeout or error.
 from __future__ import annotations
 
 import json
+import re
 import socket
 import sys
 import time
@@ -22,7 +23,7 @@ import urllib.request
 from json import JSONDecodeError
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlparse
+from urllib.parse import unquote, urljoin, urlparse
 
 
 def fetch_json(url: str, timeout: float = 10.0) -> dict[str, Any]:
@@ -45,22 +46,83 @@ def pep503_normalize(name: str) -> str:
     return re.sub(r"[-_.]+", "-", name).lower()
 
 
-def is_version_available(package: str, version: str, timeout: float = 10.0) -> bool:
-    """Check PyPI Simple API for availability of a specific version.
+#: Host serving the actual distribution files. The simple index lives on
+#: pypi.org and links out to here, and the two propagate independently.
+FILES_HOST = "files.pythonhosted.org"
 
-    Uses the PEP 503 simple index HTML, which pip consults when installing.
-    Returns True if any file link appears to contain the version string.
+
+def _require_allowed_url(url: str, *hosts: str) -> None:
+    """Reject anything not HTTPS on one of ``hosts``.
+
+    Guards against SSRF if a URL ever reaches here from untrusted input.
+    ``files.pythonhosted.org`` is allowed alongside ``pypi.org`` because
+    the file check below has to follow the index's own links.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc.lower() not in hosts:
+        raise ValueError(f"Refusing to fetch non-PyPI URL: {url}")
+
+
+def file_urls_for_version(
+    package: str, version: str, timeout: float = 10.0
+) -> list[str]:
+    """Return the simple index's file links for exactly ``version``.
+
+    The match is anchored on the full filename rather than a substring:
+    a bare ``<pkg>-<version>`` needle also matches ``0.1.53.1``, which
+    would let a *different* release satisfy the wait.
     """
     normalized = pep503_normalize(package)
     simple_url = f"https://pypi.org/simple/{normalized}/"
-    parsed = urlparse(simple_url)
-    if parsed.scheme != "https" or parsed.netloc.lower() != "pypi.org":
-        raise ValueError(f"Refusing to fetch non-PyPI URL: {simple_url}")
+    _require_allowed_url(simple_url, "pypi.org")
     with urllib.request.urlopen(simple_url, timeout=timeout) as r:
         html = r.read().decode("utf-8", errors="replace")
-    # Look for filename prefix like '<pkg>-<version>'
-    needle = f"{normalized}-{version}"
-    return needle in html
+
+    # Wheels escape the name with underscores (PEP 427); sdists use the
+    # raw project name. Accept either, then require the version to be
+    # followed by a wheel's '-' or an sdist's extension.
+    stem = re.escape(normalized).replace(r"\-", "[-_]")
+    pattern = re.compile(
+        rf"^{stem}-{re.escape(version)}(?:-[^/]*\.whl|\.tar\.gz|\.zip)$",
+        re.IGNORECASE,
+    )
+    urls: list[str] = []
+    for href in re.findall(r'href=[\'"]([^\'"]+)[\'"]', html):
+        # PEP 503 permits relative links; PyPI serves absolute ones to
+        # files.pythonhosted.org. Resolve against the index either way.
+        clean = urljoin(simple_url, href.split("#", 1)[0])
+        filename = unquote(clean.rsplit("/", 1)[-1])
+        if pattern.match(filename):
+            urls.append(clean)
+    return urls
+
+
+def is_fetchable(url: str, timeout: float = 10.0) -> bool:
+    """Whether ``url`` actually serves bytes right now.
+
+    Asks for a single byte. The simple index can list a release before
+    every CDN edge is serving the file, and pip downloads from a
+    different host than the index it resolved against — so "listed" and
+    "downloadable" are separate facts, and only the second one is the
+    condition a build actually needs.
+    """
+    _require_allowed_url(url, FILES_HOST, "pypi.org")
+    req = urllib.request.Request(url, headers={"Range": "bytes=0-0"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.status in (200, 206)
+
+
+def is_version_available(package: str, version: str, timeout: float = 10.0) -> bool:
+    """Whether ``version`` is both listed *and* downloadable.
+
+    Listing alone is what this used to check, and it is not enough: a
+    green check followed immediately by a 404 inside a Docker build is
+    exactly the failure this guard exists to prevent.
+    """
+    urls = file_urls_for_version(package, version, timeout=timeout)
+    if not urls:
+        return False
+    return all(is_fetchable(u, timeout=timeout) for u in urls)
 
 
 def main(argv: list[str]) -> int:
@@ -95,7 +157,7 @@ def main(argv: list[str]) -> int:
         try:
             # Check the Simple API used by pip to avoid JSON/simple propagation skew
             if is_version_available(package, version):
-                print(f"Found {package} {version} on PyPI (simple index).")
+                print(f"Found {package} {version} on PyPI (listed and downloadable).")
                 return 0
         except (URLError, HTTPError, JSONDecodeError, socket.timeout) as exc:
             # Expected transient issues; log for CI visibility and retry.

--- a/src/zyra/visualization/cli_heatmap.py
+++ b/src/zyra/visualization/cli_heatmap.py
@@ -245,11 +245,19 @@ def _handle_data_encoded(ns) -> int:
     def _load(src: str):
         from zyra.visualization.cli_utils import load_data_array
 
+        # north-up, unlike the figure path. load_geotiff_array flips a
+        # conventional GeoTIFF to south-up because heatmap and contour
+        # draw with origin="lower", which puts it back. Nothing puts it
+        # back here: write_luma_png hands the array straight to PIL, and
+        # a PNG's first row is its TOP. Taking the default wrote every
+        # frame mirrored about the equator — the same failure as #281,
+        # on the one path with no origin="lower" to save it.
         return load_data_array(
             src,
             var=getattr(ns, "var", None),
             xarray_engine=getattr(ns, "xarray_engine", None),
             band=getattr(ns, "band", 1),
+            geotiff_south_up=False,
         )
 
     def _write(src: str, dest: str) -> str:

--- a/src/zyra/visualization/cli_utils.py
+++ b/src/zyra/visualization/cli_utils.py
@@ -12,7 +12,7 @@ except Exception:  # pragma: no cover - fallback for very old Python
 from zyra.visualization.styles import DEFAULT_EXTENT, MAP_STYLES
 
 
-def load_geotiff_array(input_path: str, *, band: int = 1):
+def load_geotiff_array(input_path: str, *, band: int = 1, south_up: bool = True):
     """Read one band of a GeoTIFF as float32 with nodata mapped to NaN.
 
     NaN renders transparent in the raster visualizers, so warp fill and
@@ -65,7 +65,12 @@ def load_geotiff_array(input_path: str, *, band: int = 1):
     # Then reverse to south-up. A reversed slice is a view, so this
     # costs no second allocation; doing it before the write above would
     # have forced a copy of the whole raster.
-    if north_up:
+    # `south_up=False` returns the file's own orientation. The data-
+    # encoded writer needs that: a PNG's first row is its TOP, and the
+    # client maps v == 0 to the northernmost row, so flipping here would
+    # write the frame upside down. The figure path keeps the default,
+    # since it draws with origin="lower".
+    if north_up and south_up:
         arr = arr[::-1, :]
     return arr
 
@@ -76,6 +81,7 @@ def load_data_array(
     var: str | None = None,
     xarray_engine: str | None = None,
     band: int = 1,
+    geotiff_south_up: bool = True,
 ):
     """Load a 2D array from a ``.nc``/``.nc4``, ``.npy``, or GeoTIFF file.
 
@@ -91,6 +97,12 @@ def load_data_array(
         ``h5netcdf``, ``scipy``).
     band : int, default 1
         Band to read for GeoTIFF inputs (nodata is mapped to NaN).
+    geotiff_south_up : bool, default True
+        Whether GeoTIFF input is returned south-up (row 0 southernmost),
+        which is what the figure path needs because it draws with
+        ``origin="lower"``. Pass ``False`` to get the file's own
+        orientation, which is what anything writing a raster straight to
+        an image file needs.
 
     Returns
     -------
@@ -123,7 +135,7 @@ def load_data_array(
 
         return np.load(input_path)
     if lower.endswith((".tif", ".tiff")):
-        return load_geotiff_array(input_path, band=band)
+        return load_geotiff_array(input_path, band=band, south_up=geotiff_south_up)
     raise ValueError("Unsupported input file; use .nc, .nc4, .npy, .tif, or .tiff")
 
 

--- a/src/zyra/visualization/cli_utils.py
+++ b/src/zyra/visualization/cli_utils.py
@@ -18,15 +18,25 @@ def load_geotiff_array(input_path: str, *, band: int = 1, south_up: bool = True)
     NaN renders transparent in the raster visualizers, so warp fill and
     masked regions disappear instead of plotting as a solid value.
 
-    The returned array is **south-up** — row 0 is the southernmost row.
-    That is the convention every raster visualizer here already assumes:
-    ``heatmap`` draws with ``origin="lower"`` and ``contour`` builds its
-    y coordinates as ``linspace(south, north)``. GeoTIFFs are
+    Orientation of the returned array depends on ``south_up``, and the
+    two consumers want opposite things.
+
+    By default it is **south-up** — row 0 is the southernmost row. That
+    is the convention every *figure* visualizer here assumes: ``heatmap``
+    draws with ``origin="lower"`` and ``contour`` builds its y
+    coordinates as ``linspace(south, north)``. GeoTIFFs are
     conventionally north-up instead, so returning one as read renders it
     mirrored about the equator (see #281 — the global smoke frames put
     northern-hemisphere plumes over the Southern Ocean). The flip is
     keyed off the transform rather than assumed, so a genuinely south-up
-    GeoTIFF is left alone.
+    GeoTIFF is left alone either way.
+
+    With ``south_up=False`` the file's own row order is preserved, so a
+    conventional north-up GeoTIFF comes back north-up. That is what the
+    data-encoded writer needs: ``write_luma_png`` hands the array
+    straight to PIL and a PNG's first row is its **top**, with no
+    ``origin="lower"`` anywhere to undo a flip. Taking the default there
+    reproduced #281 on the one path it could not have covered.
 
     Parameters
     ----------
@@ -34,6 +44,12 @@ def load_geotiff_array(input_path: str, *, band: int = 1, south_up: bool = True)
         Path to a ``.tif``/``.tiff`` file.
     band : int, default 1
         1-based band index to read.
+    south_up : bool, default True
+        Whether to return the array south-up (row 0 southernmost),
+        flipping a north-up GeoTIFF to match. Pass ``False`` to keep the
+        file's own row order — needed when the array is written straight
+        to an image rather than drawn with ``origin="lower"``. The
+        default preserves the figure path's behaviour exactly.
 
     Raises
     ------

--- a/tests/misc/test_wait_for_pypi_validation.py
+++ b/tests/misc/test_wait_for_pypi_validation.py
@@ -45,10 +45,10 @@ def test_fetch_json_allows_pypi_https_and_reads(monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             return False
 
-    def fake_urlopen(url, timeout=10.0):  # noqa: ARG001 - match signature
+    def fake_urlopen(url, *hosts, timeout=10.0):  # noqa: ARG001 - match signature
         return FakeResponse()
 
-    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(mod, "_urlopen", fake_urlopen)
     data = mod.fetch_json("https://pypi.org/pypi/pkg/json")
     assert isinstance(data, dict)
     assert "releases" in data
@@ -104,14 +104,14 @@ def test_is_version_available_checks_simple_and_then_the_file(monkeypatch):
 
     seen: list[str] = []
 
-    def fake_urlopen(url, timeout=10.0):  # noqa: ARG001
+    def fake_urlopen(url, *hosts, timeout=10.0):  # noqa: ARG001
         target = url if isinstance(url, str) else url.full_url
         seen.append(target)
         if target.endswith("/simple/zyra/"):
             return Resp('<a href="/packages/x/zyra-1.2.3.tar.gz">zyra-1.2.3.tar.gz</a>')
         return Resp(status=206)
 
-    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(mod, "_urlopen", fake_urlopen)
     assert mod.is_version_available("Zyra", "1.2.3") is True
     # Both hops, not just the index.
     assert any(u.endswith("/simple/zyra/") for u in seen)
@@ -145,7 +145,7 @@ def _patch_index(mod, monkeypatch, html: str):
         def __exit__(self, *a):
             return False
 
-    monkeypatch.setattr(mod.urllib.request, "urlopen", lambda *a, **k: FakeResponse())
+    monkeypatch.setattr(mod, "_urlopen", lambda *a, **k: FakeResponse())
 
 
 def test_file_urls_match_the_exact_version_not_a_prefix(monkeypatch):
@@ -186,7 +186,7 @@ def test_listed_but_unfetchable_is_not_available(monkeypatch):
     def _404(*a, **k):
         raise urllib.error.HTTPError("u", 404, "Not Found", None, None)
 
-    monkeypatch.setattr(mod.urllib.request, "urlopen", _404)
+    monkeypatch.setattr(mod, "_urlopen", _404)
     with pytest.raises(urllib.error.HTTPError):
         mod.is_fetchable(
             "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz"
@@ -212,3 +212,76 @@ def test_no_files_means_not_available(monkeypatch):
     mod = _load_wait_module()
     monkeypatch.setattr(mod, "file_urls_for_version", lambda *a, **k: [])
     assert mod.is_version_available("zyra", "0.1.53") is False
+
+
+# --- what counts as "the same host" ------------------------------------
+#
+# The guard compared `netloc`, which carries the port and any userinfo.
+# That is over-strict in one direction (a default port spelled out loud
+# is the same host) without being any safer in the other.
+
+
+def test_allowlist_accepts_an_explicit_default_port():
+    """`https://pypi.org:443/...` is pypi.org, not a stranger."""
+    mod = _load_wait_module()
+    mod._require_allowed_url("https://pypi.org:443/simple/zyra/", "pypi.org")
+
+
+def test_allowlist_is_case_insensitive_on_the_host():
+    """Hostnames are case-insensitive; the guard should be too."""
+    mod = _load_wait_module()
+    mod._require_allowed_url("https://PyPI.ORG/simple/zyra/", "pypi.org")
+    # ...including when the allowlist itself is the odd one out.
+    mod._require_allowed_url("https://pypi.org/simple/zyra/", "PyPI.org")
+
+
+def test_allowlist_is_not_fooled_by_userinfo():
+    """`https://pypi.org@evil.example/` is a request to evil.example."""
+    mod = _load_wait_module()
+    with pytest.raises(ValueError):
+        mod._require_allowed_url("https://pypi.org@evil.example/x.whl", "pypi.org")
+    with pytest.raises(ValueError):
+        mod._require_allowed_url("https://pypi.org:443@evil.example/x.whl", "pypi.org")
+
+
+# --- redirects ---------------------------------------------------------
+#
+# urllib follows redirects on its own. Validating only the URL we ask for
+# checks the one hop that was never in doubt, and checking geturl() after
+# the fact is too late: the request has already been issued. These pin
+# the check at the point where it can still refuse.
+
+
+def _redirect(mod, hosts, newurl):
+    import urllib.request
+
+    handler = mod._AllowlistRedirectHandler(hosts)
+    req = urllib.request.Request("https://pypi.org/simple/zyra/")
+    return handler.redirect_request(req, None, 302, "Found", {}, newurl)
+
+
+def test_redirect_off_the_allowlist_is_refused_before_it_is_followed():
+    mod = _load_wait_module()
+    with pytest.raises(ValueError):
+        _redirect(mod, ("pypi.org", mod.FILES_HOST), "https://evil.example/x.whl")
+
+
+def test_redirect_within_the_allowlist_is_followed():
+    """The index legitimately redirects to the files host — don't break that."""
+    mod = _load_wait_module()
+    out = _redirect(
+        mod,
+        ("pypi.org", mod.FILES_HOST),
+        f"https://{mod.FILES_HOST}/packages/ab/cd/zyra-0.1.53.tar.gz",
+    )
+    assert out is not None
+    assert out.full_url.startswith(f"https://{mod.FILES_HOST}/")
+
+
+def test_downgrade_to_http_on_redirect_is_refused():
+    """A redirect is also a way to drop out of TLS."""
+    mod = _load_wait_module()
+    with pytest.raises(ValueError):
+        _redirect(
+            mod, ("pypi.org", mod.FILES_HOST), f"http://{mod.FILES_HOST}/x.tar.gz"
+        )

--- a/tests/misc/test_wait_for_pypi_validation.py
+++ b/tests/misc/test_wait_for_pypi_validation.py
@@ -172,8 +172,20 @@ def test_file_urls_find_wheel_and_sdist(monkeypatch):
     assert all("#" not in u for u in urls)
 
 
-def test_listed_but_unfetchable_is_not_available(monkeypatch):
-    """The exact race: the index lists it, the CDN does not serve it yet."""
+def test_listed_but_unfetchable_never_ends_the_wait(monkeypatch):
+    """The exact race: the index lists it, the CDN does not serve it yet.
+
+    Driven through ``is_version_available`` and ``main``, not
+    ``is_fetchable``. An earlier version of this test called the leaf
+    directly while patching ``file_urls_for_version`` — setup for a call
+    it never made — so it asserted nothing about the aggregate that the
+    release job actually invokes, which is the only thing that decides
+    whether a build starts.
+
+    A 404 propagates rather than resolving to False: ``main`` classes it
+    as transient and retries, which is what should happen while a CDN
+    catches up. What must never happen is the wait ending green.
+    """
     mod = _load_wait_module()
     monkeypatch.setattr(
         mod,
@@ -188,9 +200,32 @@ def test_listed_but_unfetchable_is_not_available(monkeypatch):
 
     monkeypatch.setattr(mod, "_urlopen", _404)
     with pytest.raises(urllib.error.HTTPError):
-        mod.is_fetchable(
-            "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz"
-        )
+        mod.is_version_available("zyra", "0.1.53")
+
+    # End to end: retried, then gave up. Never exit 0.
+    assert mod.main(["wait_for_pypi.py", "zyra", "0.1.53", "2", "0"]) == 1
+
+
+def test_every_listed_file_must_be_fetchable(monkeypatch):
+    """One file answering is not enough to end the wait.
+
+    pip installs the wheel normally, but a source build reaches for the
+    sdist, so going green on whichever responded first says nothing
+    about the file pip will actually download. This pins the `all`, not
+    `any`, that `is_version_available` is built on.
+    """
+    mod = _load_wait_module()
+    wheel = "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53-py3-none-any.whl"
+    sdist = "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz"
+    monkeypatch.setattr(mod, "file_urls_for_version", lambda *a, **k: [wheel, sdist])
+
+    # Wheel up, sdist still propagating — not available.
+    monkeypatch.setattr(mod, "is_fetchable", lambda u, **k: u == wheel)
+    assert mod.is_version_available("zyra", "0.1.53") is False
+
+    # Only both serving is green.
+    monkeypatch.setattr(mod, "is_fetchable", lambda u, **k: True)
+    assert mod.is_version_available("zyra", "0.1.53") is True
 
 
 def test_is_fetchable_allows_the_files_host_but_not_others():

--- a/tests/misc/test_wait_for_pypi_validation.py
+++ b/tests/misc/test_wait_for_pypi_validation.py
@@ -79,13 +79,19 @@ def test_main_bubbles_unexpected_errors(monkeypatch):
         mod.main(["wait_for_pypi.py", "zyra", "9.9.9", "1", "0"])
 
 
-def test_is_version_available_checks_simple(monkeypatch):
-    """is_version_available should check the PyPI simple index for the version."""
+def test_is_version_available_checks_simple_and_then_the_file(monkeypatch):
+    """Availability now means listed *and* downloadable.
+
+    It used to mean listed only, which let the guard pass while the
+    file was still 404ing from the CDN pip fetches it from. The fake
+    below has to answer both hops for this to return True.
+    """
     mod = _load_wait_module()
 
     class Resp:
-        def __init__(self, text: str):
+        def __init__(self, text: str = "", status: int = 200):
             self._b = text.encode("utf-8")
+            self.status = status
 
         def __enter__(self):
             return self
@@ -96,10 +102,113 @@ def test_is_version_available_checks_simple(monkeypatch):
         def read(self):
             return self._b
 
+    seen: list[str] = []
+
     def fake_urlopen(url, timeout=10.0):  # noqa: ARG001
-        assert url.endswith("/simple/zyra/")
-        # Include the normalized filename pattern with version
-        return Resp('<a href="/packages/.../zyra-1.2.3.tar.gz">zyra-1.2.3.tar.gz</a>')
+        target = url if isinstance(url, str) else url.full_url
+        seen.append(target)
+        if target.endswith("/simple/zyra/"):
+            return Resp('<a href="/packages/x/zyra-1.2.3.tar.gz">zyra-1.2.3.tar.gz</a>')
+        return Resp(status=206)
 
     monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
     assert mod.is_version_available("Zyra", "1.2.3") is True
+    # Both hops, not just the index.
+    assert any(u.endswith("/simple/zyra/") for u in seen)
+    assert any("zyra-1.2.3.tar.gz" in u for u in seen)
+
+
+# --- file-level availability -------------------------------------------
+#
+# The old check asked the simple index whether the version was *listed*.
+# pip downloads from files.pythonhosted.org, a different host behind a
+# different CDN, so "listed" and "downloadable" propagate independently:
+# the guard went green and the very next `pip install` 404'd inside the
+# Docker build. These cover the gap that closes.
+
+
+def _index_html(*filenames: str) -> str:
+    links = "".join(
+        f'<a href="https://files.pythonhosted.org/packages/ab/cd/{f}#sha256=x">{f}</a>'
+        for f in filenames
+    )
+    return f"<html><body>{links}</body></html>"
+
+
+def _patch_index(mod, monkeypatch, html: str):
+    class FakeResponse:
+        def __enter__(self):
+            import io
+
+            return io.BytesIO(html.encode())
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", lambda *a, **k: FakeResponse())
+
+
+def test_file_urls_match_the_exact_version_not_a_prefix(monkeypatch):
+    """`0.1.53` must not be satisfied by `0.1.53.1`.
+
+    The previous substring check accepted it, so a *different* release
+    could end the wait.
+    """
+    mod = _load_wait_module()
+    _patch_index(mod, monkeypatch, _index_html("zyra-0.1.53.1.tar.gz"))
+    assert mod.file_urls_for_version("zyra", "0.1.53") == []
+
+
+def test_file_urls_find_wheel_and_sdist(monkeypatch):
+    mod = _load_wait_module()
+    _patch_index(
+        mod,
+        monkeypatch,
+        _index_html("zyra-0.1.53-py3-none-any.whl", "zyra-0.1.53.tar.gz"),
+    )
+    urls = mod.file_urls_for_version("zyra", "0.1.53")
+    assert len(urls) == 2
+    # The fragment is stripped so the URL can be fetched directly.
+    assert all("#" not in u for u in urls)
+
+
+def test_listed_but_unfetchable_is_not_available(monkeypatch):
+    """The exact race: the index lists it, the CDN does not serve it yet."""
+    mod = _load_wait_module()
+    monkeypatch.setattr(
+        mod,
+        "file_urls_for_version",
+        lambda *a, **k: [
+            "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz"
+        ],
+    )
+
+    def _404(*a, **k):
+        raise urllib.error.HTTPError("u", 404, "Not Found", None, None)
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", _404)
+    with pytest.raises(urllib.error.HTTPError):
+        mod.is_fetchable(
+            "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz"
+        )
+
+
+def test_is_fetchable_allows_the_files_host_but_not_others():
+    """The file check has to follow the index's links off pypi.org."""
+    mod = _load_wait_module()
+    mod._require_allowed_url(
+        "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz",
+        "files.pythonhosted.org",
+    )
+    with pytest.raises(ValueError):
+        mod._require_allowed_url("https://evil.example/x.whl", "files.pythonhosted.org")
+    with pytest.raises(ValueError):
+        mod._require_allowed_url(
+            "http://files.pythonhosted.org/x.whl", "files.pythonhosted.org"
+        )
+
+
+def test_no_files_means_not_available(monkeypatch):
+    mod = _load_wait_module()
+    monkeypatch.setattr(mod, "file_urls_for_version", lambda *a, **k: [])
+    assert mod.is_version_available("zyra", "0.1.53") is False

--- a/tests/visualization/test_geotiff_input.py
+++ b/tests/visualization/test_geotiff_input.py
@@ -234,9 +234,9 @@ def test_heatmap_renders_geotiff_with_transparent_nodata(tmp_path):
     h, w = img.shape[:2]
     left = img[h // 2, w // 4]
     right = img[h // 2, (3 * w) // 4]
-    assert (
-        abs(int(left.sum()) - int(right.sum())) > 60
-    ), f"nodata half was painted with data color: left={left}, right={right}"
+    assert abs(int(left.sum()) - int(right.sum())) > 60, (
+        f"nodata half was painted with data color: left={left}, right={right}"
+    )
     # Background is neutral (grayscale-ish), data color is not.
     assert max(left) - min(left) < 30, f"nodata pixel not background-like: {left}"
 
@@ -344,3 +344,45 @@ def test_south_up_geotiff_is_left_alone(tmp_path):
     assert out[:4].max() == 0.0
     assert out[4:].min() == 1.0
     np.testing.assert_array_equal(out, data)
+
+
+def test_south_up_false_returns_the_files_own_orientation(tmp_path):
+    """`south_up=False` keeps a north-up GeoTIFF north-up.
+
+    The data-encoded writer needs this. `write_luma_png` hands the array
+    straight to PIL and a PNG's first row is its TOP, with the client
+    mapping v == 0 to the northernmost row — so the flip that makes the
+    figure path correct writes a data frame mirrored about the equator.
+    Same failure as #281, on the one path with no ``origin="lower"`` to
+    put it back.
+    """
+    tif = str(tmp_path / "north_up_keep.tif")
+    data = np.zeros((8, 4), dtype="float32")
+    data[:4, :] = 1.0  # north half hot, in north-up row order
+    _write_tif(tif, data)
+
+    out = load_geotiff_array(tif, south_up=False)
+
+    assert out[:4].min() == 1.0, "row 0 should still be the northernmost"
+    assert out[4:].max() == 0.0
+
+    # …and the default is unchanged, so the figure path is untouched.
+    assert load_geotiff_array(tif)[:4].max() == 0.0
+
+
+def test_load_data_array_threads_the_orientation_flag(tmp_path):
+    """The flag has to survive the load_data_array wrapper.
+
+    That wrapper is what the data-encoded handler actually calls, so a
+    parameter that stops at the GeoTIFF helper would look correct in
+    isolation and do nothing in production.
+    """
+    from zyra.visualization.cli_utils import load_data_array
+
+    tif = str(tmp_path / "threaded.tif")
+    data = np.zeros((8, 4), dtype="float32")
+    data[:4, :] = 1.0
+    _write_tif(tif, data)
+
+    assert load_data_array(tif, geotiff_south_up=False)[:4].min() == 1.0
+    assert load_data_array(tif)[:4].max() == 0.0

--- a/tests/visualization/test_geotiff_input.py
+++ b/tests/visualization/test_geotiff_input.py
@@ -234,9 +234,9 @@ def test_heatmap_renders_geotiff_with_transparent_nodata(tmp_path):
     h, w = img.shape[:2]
     left = img[h // 2, w // 4]
     right = img[h // 2, (3 * w) // 4]
-    assert abs(int(left.sum()) - int(right.sum())) > 60, (
-        f"nodata half was painted with data color: left={left}, right={right}"
-    )
+    assert (
+        abs(int(left.sum()) - int(right.sum())) > 60
+    ), f"nodata half was painted with data color: left={left}, right={right}"
     # Background is neutral (grayscale-ish), data color is not.
     assert max(left) - min(left) < 30, f"nodata pixel not background-like: {left}"
 


### PR DESCRIPTION
0.1.53 added `visualize heatmap --data-encoded`, a second output from the same command that writes value-exact grayscale instead of a picture. The first live pipeline to use it published its frames upside down.

The cause is a convention doing its job in a place that no longer has the matching half. `load_geotiff_array` returns a conventional north-up GeoTIFF **south-up**, on purpose: `heatmap` and `contour` draw with `origin="lower"`, which puts it back, and returning it as read is what mirrored northern-hemisphere plumes over the Southern Ocean in 0.1.52. The data-encoded path has no `origin="lower"` — `write_luma_png` hands the array straight to PIL and a PNG's first row is its top — so the flip stayed flipped. Same bug class as the one 0.1.52 fixed, on the one path that fix could not have covered because the path did not exist yet.

What makes it a bug rather than a convention is that the two outputs of a single command disagreed: the same GeoTIFF through `visualize heatmap` and through `visualize heatmap --data-encoded` needed opposite orientation settings downstream.

The other fix in this release is release tooling. `wait_for_pypi.py` exists so an image build never starts before the version it installs is published, and it has been intermittently letting one through anyway.

**Visualization**

*   `--data-encoded` now writes GeoTIFF-sourced frames north-up ([#357](https://github.com/NOAA-GSL/zyra/pull/357)). `load_geotiff_array` gains a `south_up` parameter defaulting to `True`, so the figure path is byte-for-byte unchanged; `load_data_array` threads it through as `geotiff_south_up`, since that wrapper — not the helper — is what the data-encoded handler actually calls, and a parameter stopping at the helper would have looked correct in review and done nothing in production. Only the GeoTIFF branch is affected: `.npy` and NetCDF inputs are returned exactly as the file stores them, because nothing at this layer knows their latitude order and inventing a flip for them would be guessing.

**Release tooling**

*   `wait_for_pypi.py` now verifies the files are downloadable, not merely listed ([#356](https://github.com/NOAA-GSL/zyra/pull/356)). It polled `pypi.org/simple/NAME/`; pip *resolves* against that index but *downloads* from `files.pythonhosted.org`, a different host behind a different CDN propagating independently. The index can list a release before every edge is serving the file, so the guard went green, buildx started, and the download 404'd — the release was fine and a rerun always fixed it, which is exactly what a CDN race looks like. The script now parses the index's own links and issues a ranged GET against **every** one, requiring all of them to serve bytes. Requiring only the first to answer would pick the wrong file as often as not: pip installs the wheel normally, but a source build reaches for the sdist. The SSRF allowlist gains `files.pythonhosted.org` and both hops are checked through one helper rather than two copies of the same three lines.
*   Two smaller faults in the same script, both surfaced by writing the tests ([#356](https://github.com/NOAA-GSL/zyra/pull/356)). The version match was a substring of `NAME-VERSION`, which `0.1.53.1` also satisfies while waiting for `0.1.53` — a *different* release could end the wait. It is now anchored on the whole filename, accepting a wheel's escaped name or an sdist's extension. Separately, relative `href`s were rejected outright by the host guard; PEP 503 permits them and PyPI happens to serve absolute ones, so this never bit, but the assumption was unnecessary and they now resolve against the index URL.
*   The script's host allowlist is enforced on redirects, not just on the URL requested ([#356](https://github.com/NOAA-GSL/zyra/pull/356)). urllib follows redirects on its own, so checking only what we ask for validates the one hop that was never in doubt — a 302 off the allowlist was followed and the request issued before anything looked at it. The check now runs in a redirect handler, before the hop goes out, and every fetch in the script routes through one seam so a future call site cannot skip it. The comparison also moved from `netloc` to `hostname`, which normalises an explicit `:443` away rather than refusing it as a different host.

**Compatibility**

*   **Data-encoded output is inverted by this release, and that requires an action downstream.** Any dataset already published from `--data-encoded` frames was corrected at display time — in terraviz, with the publisher's *"flipped in Y"* checkbox — and that correction is now wrong. **Un-tick it** once the pipeline has re-run against this version. There is exactly one such dataset today, the RRFS smoke run that surfaced the bug, so the blast radius is a single row; `--data-encoded` shipped in 0.1.53 and no correct output is being invalidated.
*   **The figure path is untouched.** `south_up` defaults to the current behaviour and only the data-encoded handler opts out. The existing orientation tests from 0.1.52 are unchanged and still pass, and the new tests assert the default alongside the override rather than only the new case.
*   **`is_version_available` now means listed *and* downloadable** where it used to mean listed. That is the point of the change, but it alters an existing contract, so its pre-existing test was updated to answer both hops. The check is strictly more conservative — it cannot pass where the old one failed — and the worst case is waiting longer, bounded by the same `retries × delay` (default 60 × 10s).
*   **This narrows the PyPI race rather than closing it.** The wait runs on the runner; `pip install` runs inside BuildKit, and they need not share a CDN edge, so a fresh view in one does not guarantee a fresh view in the other. The `zyra` image also builds arm64 under QEMU, which starts later and runs considerably longer, widening the window further. A pip retry inside the Dockerfiles is the belt-and-braces companion and was deliberately left out to keep this to one idea.

Two bug fixes, no new surface. No CLI flags, no API model fields, no schema change, and nothing to regenerate. Rollback is a straight revert in both cases — no migrations and no persisted state — with the one caveat that reverting the orientation fix re-inverts data-encoded frames and puts the downstream checkbox back.
